### PR TITLE
Fix example's docker-compose.yml `environment` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ func processRequest() {
 ### Retrieving the context from an http request
 
 A common pattern when tracing in golang is to call `ao.HTTPHandler(handler)` then retrieve the trace
-context inside of the handler.  
+context inside of the handler.
 ```go
 
 func myHandler( w http.ResponseWriter, r *http.Request ) {
@@ -222,7 +222,7 @@ func main() {
 
 ### Distributed tracing and context propagation
 
-A AppOptics trace is defined by a context (a globally unique ID and metadata) that is persisted
+An AppOptics trace is defined by a context (a globally unique ID and metadata) that is persisted
 across the different hosts, processes, languages and methods that are used to serve a request. Thus
 to start a new Span you need either a Trace or another Span to begin from. (The Trace
 interface is also the root Span, typically created when a request is first received.) Each new

--- a/examples/distributed_app/docker-compose.yml
+++ b/examples/distributed_app/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     build:
       context: ./alice
     environment:
-      - APPOPTICS_SERVICE_KEY: ${APPOPTICS_SERVICE_KEY}
+      APPOPTICS_SERVICE_KEY: ${APPOPTICS_SERVICE_KEY}
     links:
       - bob
       - caroljs:carol
@@ -24,7 +24,7 @@ services:
     build:
       context: ./bob
     environment:
-      - APPOPTICS_SERVICE_KEY: ${APPOPTICS_SERVICE_KEY}
+      APPOPTICS_SERVICE_KEY: ${APPOPTICS_SERVICE_KEY}
     links:
       - redis
       - caroljs:carol
@@ -34,21 +34,21 @@ services:
     build:
       context: ./caroljs
     environment:
-      - APPOPTICS_SERVICE_KEY: ${APPOPTICS_SERVICE_KEY}
+      APPOPTICS_SERVICE_KEY: ${APPOPTICS_SERVICE_KEY}
 
   # Dave is a Flask app running on uWSGI
   davepy:
     build:
       context: ./davepy
     environment:
-      - APPOPTICS_SERVICE_KEY: ${APPOPTICS_SERVICE_KEY}
+      APPOPTICS_SERVICE_KEY: ${APPOPTICS_SERVICE_KEY}
 
   # Otto is a Go app using the OpenTracing API
   otto:
     build:
       context: ./otto
     environment:
-      - APPOPTICS_SERVICE_KEY: ${APPOPTICS_SERVICE_KEY}
+      APPOPTICS_SERVICE_KEY: ${APPOPTICS_SERVICE_KEY}
     links:
       - bob
       - caroljs:carol


### PR DESCRIPTION
My docker-compose (1.18.0) complains that this wasn't the right type. The yaml here was defining environment as one-item lists containing a map with a single key/value (I think; yaml can be confusing).

```
$ docker-compose build
...
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.alice.environment contains {"APPOPTICS_SERVICE_KEY": ""}, which is an invalid type, it should be a string
services.bob.environment contains {"APPOPTICS_SERVICE_KEY": ""}, which is an invalid type, it should be a string
services.caroljs.environment contains {"APPOPTICS_SERVICE_KEY": ""}, which is an invalid type, it should be a string
services.davepy.environment contains {"APPOPTICS_SERVICE_KEY": ""}, which is an invalid type, it should be a string
services.otto.environment contains {"APPOPTICS_SERVICE_KEY": ""}, which is an invalid type, it should be a string
```