### PR TITLE
AO-8242 Let APPOPTICS_DEBUG_LEVEL support string values

### DIFF
--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -73,7 +73,7 @@ func readEnvSettings() {
 	}
 
 	if level := os.Getenv("APPOPTICS_DEBUG_LEVEL"); level != "" {
-		// We don not want to break backward-compatibility so keep accepting integer value
+		// We do not want to break backward-compatibility so keep accepting integer values.
 		if i, err := strconv.Atoi(level); err == nil {
 			// Protect the debug level from some invalid value, e.g., 1000
 			if i >= len(dbgLevels) {


### PR DESCRIPTION
This PR is to fix the issue `Go: APPOPTICS_DEBUG_LEVEL docs and implementation are different` on Jira.

Now with this fix it supports both integers(for backward compatibility) and string values (which is case-insensitive, e.g., debug, INFO or Error)