### PR TITLE
AO-8294: agent versioning

### DIFF
--- a/v1/ao/Makefile
+++ b/v1/ao/Makefile
@@ -36,7 +36,7 @@ are-you-sure:
 		$(eval confirmed := "Yes")
 
 # Change the value of initVersion and tag it with the version number.
-# Usage: make VERSION=blabla tag-and-release
+# Usage: make VERSION=1.2.3 tag-and-release
 tag-and-release: are-you-sure
 	# VERSION must be set
 	@if [ -z "$$VERSION" ]; then \

--- a/v1/ao/Makefile
+++ b/v1/ao/Makefile
@@ -55,9 +55,9 @@ tag-and-release: are-you-sure
 	# Replace the version with the value provided by you
 	# Please note that this does not work with sed on a Mac.
 	# Install the GNU sed with `brew install gnu-sed --with-default-names` first
-	@sed -i 's/const initVersion = ".*"/const initVersion = "${VERSION}"/' v1/ao/internal/reporter/version.go
+	@sed -i 's/const initVersion = ".*"/const initVersion = "${VERSION}"/' internal/reporter/version.go
 	# And commit it
-	@git add v1/ao/internal/reporter/version.go
+	@git add internal/reporter/version.go
 	@git commit -m "Changed version to ${VERSION}"
 	# Now we create tags as a release
 	@git tag -a ${VERSION} -m "Version: ${VERSION}"

--- a/v1/ao/Makefile
+++ b/v1/ao/Makefile
@@ -1,3 +1,7 @@
+SHELL=bash
+
+prev_branch :=$(shell git rev-parse --abbrev-ref HEAD)
+
 coverpkg="github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao,github.com/appoptics/appoptics-apm-go/v1/ao/opentracing"
 cov_args=-covermode=atomic -coverpkg=$(coverpkg)
 cov_out=-coverprofile=cov.out
@@ -21,3 +25,44 @@ $(cov_merge): test $(cov_files)
 
 coverhtml: $(cov_merge)
 	go tool cover -html=$(cov_merge)
+
+are-you-sure:
+	@read -p "I suppose you know what you are doing. Are you sure? [Y/n]" -n 1 -r; \
+	if [[ $$REPLY != "Y" ]]; then \
+		echo -e -n "\nSee you. >> "; \
+		exit 1; \
+	fi
+	@echo -e "\nGood, proceeding..."; \
+		$(eval confirmed := "Yes")
+
+# Change the value of initVersion and tag it with the version number.
+# Usage: make VERSION=blabla tag-and-release
+tag-and-release: are-you-sure
+	# VERSION must be set
+	@if [ -z "$$VERSION" ]; then \
+		echo -e "The VERSION is unset or an empty string"; \
+		exit 1; \
+	fi
+	# Let you know what you are doing.
+	@echo -e "Changing the version number and tag it with ${VERSION}."
+	# Stash your current work, in case of any
+	@git stash
+	# We tag and release on the master branch
+	@git checkout master
+	# Make sure it's up-to-date
+	@git fetch origin
+	@git reset --hard origin/master
+	# Replace the version with the value provided by you
+	# Please note that this does not work with sed on a Mac.
+	# Install the GNU sed with `brew install gnu-sed --with-default-names` first
+	@sed -i 's/const initVersion = ".*"/const initVersion = "${VERSION}"/' v1/ao/internal/reporter/version.go
+	# And commit it
+	@git add v1/ao/internal/reporter/version.go
+	@git commit -m "Changed version to ${VERSION}"
+	# Now we create tags as a release
+	@git tag -a ${VERSION} -m "Version: ${VERSION}"
+	# Push it to the remote master branch
+	@git push origin master --follow-tags
+	# Resume your workspace
+	@git checkout ${prev_branch}
+	@git stash pop

--- a/v1/ao/Makefile
+++ b/v1/ao/Makefile
@@ -53,9 +53,8 @@ tag-and-release: are-you-sure
 	@git fetch origin
 	@git reset --hard origin/master
 	# Replace the version with the value provided by you
-	# Please note that this does not work with sed on a Mac.
-	# Install the GNU sed with `brew install gnu-sed --with-default-names` first
-	@sed -i 's/const initVersion = ".*"/const initVersion = "${VERSION}"/' internal/reporter/version.go
+	@sed -i.bak -e 's/const initVersion = ".*"/const initVersion = "${VERSION}"/' internal/reporter/version.go \
+		&& rm internal/reporter/version.go.bak
 	# And commit it
 	@git add internal/reporter/version.go
 	@git commit -m "Changed version to ${VERSION}"

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -83,7 +83,7 @@ func readEnvSettings() {
 		} else if offset := ElemOffset(dbgLevels, strings.ToUpper(level)); offset != -1 {
 			debugLevel = DebugLevel(offset)
 		} else {
-			OboeLog(WARNING, "invalid debug level: %s", level)
+			OboeLog(WARNING, fmt.Sprintf("invalid debug level: %s", level))
 		}
 	}
 }

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -80,7 +80,7 @@ func readEnvSettings() {
 				i = len(dbgLevels) - 1
 			}
 			debugLevel = DebugLevel(i)
-		} else if offset := ElemOffset(dbgLevels, strings.ToUpper(level)); offset != -1 {
+		} else if offset := ElemOffset(dbgLevels, strings.ToUpper(strings.TrimSpace(level))); offset != -1 {
 			debugLevel = DebugLevel(offset)
 		} else {
 			OboeLog(WARNING, fmt.Sprintf("invalid debug level: %s", level))

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -88,8 +88,6 @@ func readEnvSettings() {
 	}
 }
 
-const initVersion = 1
-
 func sendInitMessage() {
 	ctx := newContext(true)
 	if c, ok := ctx.(*oboeContext); ok {
@@ -101,7 +99,7 @@ func sendInitMessage() {
 
 		e.AddKV("__Init", 1)
 		e.AddKV("Go.Version", runtime.Version())
-		e.AddKV("Go.Oboe.Version", strconv.Itoa(initVersion))
+		e.AddKV("Go.Oboe.Version", initVersion)
 
 		e.ReportStatus(c)
 	}

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -73,10 +73,17 @@ func readEnvSettings() {
 	}
 
 	if level := os.Getenv("APPOPTICS_DEBUG_LEVEL"); level != "" {
+		// We don not want to break backward-compatibility so keep accepting integer value
 		if i, err := strconv.Atoi(level); err == nil {
+			// Protect the debug level from some invalid value, e.g., 1000
+			if i >= len(dbgLevels) {
+				i = len(dbgLevels) - 1
+			}
 			debugLevel = DebugLevel(i)
+		} else if offset := ElemOffset(dbgLevels, strings.ToUpper(level)); offset != -1 {
+			debugLevel = DebugLevel(offset)
 		} else {
-			OboeLog(WARNING, "The debug level should be an integer.")
+			OboeLog(WARNING, "invalid debug level: %s", level)
 		}
 	}
 }

--- a/v1/ao/internal/reporter/oboe_test.go
+++ b/v1/ao/internal/reporter/oboe_test.go
@@ -448,6 +448,10 @@ func TestDebugLevel(t *testing.T) {
 	readEnvSettings()
 	assert.EqualValues(t, debugLevel, DebugLevel(3))
 
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", " erroR  ")
+	readEnvSettings()
+	assert.EqualValues(t, debugLevel, DebugLevel(3))
+
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "HelloWorld")
 	readEnvSettings()
 	assert.EqualValues(t, debugLevel, DebugLevel(3))

--- a/v1/ao/internal/reporter/oboe_test.go
+++ b/v1/ao/internal/reporter/oboe_test.go
@@ -6,7 +6,6 @@ package reporter
 
 import (
 	"os"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -33,7 +32,7 @@ func assertInitMessage(t *testing.T, bufs [][]byte) {
 	g.AssertGraph(t, bufs, 1, g.AssertNodeMap{
 		{"go", "single"}: {Edges: g.Edges{}, Callback: func(n g.Node) {
 			assert.Equal(t, 1, n.Map["__Init"])
-			assert.Equal(t, strconv.Itoa(initVersion), n.Map["Go.Oboe.Version"])
+			assert.Equal(t, initVersion, n.Map["Go.Oboe.Version"])
 			assert.NotEmpty(t, n.Map["Go.Version"])
 		}},
 	})

--- a/v1/ao/internal/reporter/oboe_test.go
+++ b/v1/ao/internal/reporter/oboe_test.go
@@ -450,7 +450,7 @@ func TestDebugLevel(t *testing.T) {
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "HelloWorld")
 	readEnvSettings()
-	assert.EqualValues(t, debugLevel, DebugLevel(0))
+	assert.EqualValues(t, debugLevel, DebugLevel(3))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "0")
 	readEnvSettings()
@@ -478,5 +478,5 @@ func TestDebugLevel(t *testing.T) {
 
 	os.Unsetenv("APPOPTICS_DEBUG_LEVEL")
 	readEnvSettings()
-	assert.EqualValues(t, debugLevel, DebugLevel(0))
+	assert.EqualValues(t, debugLevel, DebugLevel(3))
 }

--- a/v1/ao/internal/reporter/oboe_test.go
+++ b/v1/ao/internal/reporter/oboe_test.go
@@ -427,3 +427,56 @@ func TestOboeTracingMode(t *testing.T) {
 
 	r.Close(0)
 }
+
+func TestDebugLevel(t *testing.T) {
+	r := SetTestReporter()
+	defer r.Close(0)
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "DEBUG")
+	readEnvSettings()
+	assert.EqualValues(t, debugLevel, DebugLevel(0))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "Info")
+	readEnvSettings()
+	assert.EqualValues(t, debugLevel, DebugLevel(1))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "warn")
+	readEnvSettings()
+	assert.EqualValues(t, debugLevel, DebugLevel(2))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "erroR")
+	readEnvSettings()
+	assert.EqualValues(t, debugLevel, DebugLevel(3))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "HelloWorld")
+	readEnvSettings()
+	assert.EqualValues(t, debugLevel, DebugLevel(0))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "0")
+	readEnvSettings()
+	assert.EqualValues(t, debugLevel, DebugLevel(0))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "1")
+	readEnvSettings()
+	assert.EqualValues(t, debugLevel, DebugLevel(1))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "2")
+	readEnvSettings()
+	assert.EqualValues(t, debugLevel, DebugLevel(2))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "3")
+	readEnvSettings()
+	assert.EqualValues(t, debugLevel, DebugLevel(3))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "4")
+	readEnvSettings()
+	assert.EqualValues(t, debugLevel, DebugLevel(3))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "1000")
+	readEnvSettings()
+	assert.EqualValues(t, debugLevel, DebugLevel(3))
+
+	os.Unsetenv("APPOPTICS_DEBUG_LEVEL")
+	readEnvSettings()
+	assert.EqualValues(t, debugLevel, DebugLevel(0))
+}

--- a/v1/ao/internal/reporter/reporter_grpc_test.go
+++ b/v1/ao/internal/reporter/reporter_grpc_test.go
@@ -83,8 +83,8 @@ func (s *TestGRPCServer) GetSettings(ctx context.Context, req *pb.SettingsReques
 			// Timestamp: XXX,
 			Value:     1000000,
 			Arguments: map[string][]byte{
-			//   "BucketCapacity": XXX,
-			//   "BucketRate":     XXX,
+				//   "BucketCapacity": XXX,
+				//   "BucketRate":     XXX,
 			},
 			Ttl: 120,
 		}},

--- a/v1/ao/internal/reporter/reporter_test.go
+++ b/v1/ao/internal/reporter/reporter_test.go
@@ -4,6 +4,7 @@ package reporter
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"net"
 	"os"
@@ -261,4 +262,9 @@ func TestGRPCReporter(t *testing.T) {
 	assert.Equal(t, dec3["Hostname"], cachedHostname)
 	assert.Equal(t, dec2["Distro"], getDistro())
 	assert.Equal(t, dec3["Distro"], getDistro())
+
+	fmt.Println("dec1: ", dec1)
+	fmt.Println("dec2: ", dec2)
+	fmt.Println("dec3: ", dec3)
+	fmt.Println("dec4: ", dec4)
 }

--- a/v1/ao/internal/reporter/reporter_test.go
+++ b/v1/ao/internal/reporter/reporter_test.go
@@ -4,7 +4,6 @@ package reporter
 
 import (
 	"errors"
-	"fmt"
 	"log"
 	"net"
 	"os"
@@ -213,6 +212,7 @@ func TestGRPCReporter(t *testing.T) {
 
 	assert.Error(t, r.reportStatus(nil, nil))
 	assert.Error(t, r.reportStatus(ctx, nil))
+	time.Sleep(time.Millisecond * 100)
 	assert.NoError(t, r.reportStatus(ctx, ev2))
 
 	assert.Equal(t, addr, r.eventConnection.address)
@@ -263,8 +263,8 @@ func TestGRPCReporter(t *testing.T) {
 	assert.Equal(t, dec2["Distro"], getDistro())
 	assert.Equal(t, dec3["Distro"], getDistro())
 
-	fmt.Println("dec1: ", dec1)
-	fmt.Println("dec2: ", dec2)
-	fmt.Println("dec3: ", dec3)
-	fmt.Println("dec4: ", dec4)
+	t.Logf("dec1: ", dec1)
+	t.Logf("dec2: ", dec2)
+	t.Logf("dec3: ", dec3)
+	t.Logf("dec4: ", dec4)
 }

--- a/v1/ao/internal/reporter/utils.go
+++ b/v1/ao/internal/reporter/utils.go
@@ -40,19 +40,29 @@ const (
 	ERROR
 )
 
-var dbgLevels = map[DebugLevel]string{
+var dbgLevels = []string{
 	DEBUG:   "DEBUG",
 	INFO:    "INFO ",
 	WARNING: "WARN ",
 	ERROR:   "ERROR",
 }
 
-var debugLevel DebugLevel = ERROR
-var debugLog bool = true
+var debugLevel = ERROR
+var debugLog = true
+
+// ElemOffset is a simple helper function to check if a slice contains a specific element
+func ElemOffset(s []string, e string) int {
+	for idx, i := range s {
+		if e == i {
+			return idx
+		}
+	}
+	return -1
+}
 
 // OboeLog print logs based on the debug level.
 func OboeLog(level DebugLevel, msg string, args ...interface{}) {
-	if !debugLog || level < debugLevel {
+	if !debugLog || level < debugLevel { // debugLog is always true for now.
 		return
 	}
 	var p string

--- a/v1/ao/internal/reporter/utils.go
+++ b/v1/ao/internal/reporter/utils.go
@@ -42,8 +42,8 @@ const (
 
 var dbgLevels = []string{
 	DEBUG:   "DEBUG",
-	INFO:    "INFO ",
-	WARNING: "WARN ",
+	INFO:    "INFO",
+	WARNING: "WARN",
 	ERROR:   "ERROR",
 }
 

--- a/v1/ao/internal/reporter/version.go
+++ b/v1/ao/internal/reporter/version.go
@@ -6,4 +6,4 @@ package reporter
 Do not change this file manually. It will be modified by `make tag-and-release`.
 Check the Makefile for more details.
 */
-const initVersion = "1.0.1"
+const initVersion = "1.0.2"

--- a/v1/ao/internal/reporter/version.go
+++ b/v1/ao/internal/reporter/version.go
@@ -6,4 +6,4 @@ package reporter
 Do not change this file manually. It will be modified by `make tag-and-release`.
 Check the Makefile for more details.
 */
-const initVersion = "1"
+const initVersion = "1.0.1"

--- a/v1/ao/internal/reporter/version.go
+++ b/v1/ao/internal/reporter/version.go
@@ -1,0 +1,9 @@
+// Copyright (C) 2017 Librato, Inc. All rights reserved.
+
+package reporter
+
+/*
+Do not change this file manually. It will be modified by `make tag-and-release`.
+Check the Makefile for more details.
+*/
+const initVersion = "1"


### PR DESCRIPTION
For https://swicloud.atlassian.net/secure/RapidBoard.jspa?rapidView=88&projectKey=AO&modal=detail&selectedIssue=AO-8294

Basically it's a small improvement that we can use a single command `make VERSION=1.2.3 tag-and-release` to do the following work:
1. Replace the value of constant `initVersion`  with _1.2.3_ and commit it to the master branch
2. Tag the current commit point with the name `1.2.3`

The value of `initVersion` is used to report `Oboe.Go.Version`