### PR TITLE
AO-8243 Proper logging for connections issues 

### DIFF
--- a/v1/ao/internal/reporter/reporter.go
+++ b/v1/ao/internal/reporter/reporter.go
@@ -5,7 +5,6 @@ package reporter
 import (
 	"bytes"
 	"errors"
-	"log"
 	"os"
 	"strings"
 	"time"
@@ -77,7 +76,7 @@ func cacheHostname(hn hostnamer) {
 	h, err := hn.Hostname()
 	if err != nil {
 		if debugLog {
-			log.Printf("Unable to get hostname, AppOptics tracing disabled: %v", err)
+			OboeLog(ERROR, "Unable to get hostname, AppOptics tracing disabled: %v", err)
 		}
 		reportingDisabled = true
 	}

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -860,6 +860,9 @@ func (r *grpcReporter) statusSender() {
 
 		// we'll stay in this loop until the call to PostEvents() succeeds
 		resultOk := false
+		failsNum := 0
+		failsPrinted := false
+
 		for !resultOk {
 			// protect the call to the client object or we could run into problems if
 			// another goroutine is messing with it at the same time, e.g. doing a reconnect()
@@ -871,10 +874,21 @@ func (r *grpcReporter) statusSender() {
 			r.metricConnection.resetPing()
 
 			if err != nil {
-				OboeLog(INFO, fmt.Sprintf("Error calling PostStatus(): %v", err))
-				// some server connection error, attempt reconnect
-				r.reconnect(r.metricConnection, POSTSTATUS)
+				// gRPC handles the reconnection automatically.
+				failsNum++
+				if failsNum > 10 && !failsPrinted {
+					OboeLog(WARNING, fmt.Sprintf("Error calling PostStatus(): %v", err))
+					failsPrinted = true
+				} else {
+					OboeLog(DEBUG, fmt.Sprintf("(%v) Error calling PostStatus(): %v", failsNum, err))
+				}
 			} else {
+				if failsPrinted {
+					OboeLog(WARNING, fmt.Sprintf("Error resumed in PostStatus()"))
+					// Reset the flags here as there might be extra retries even the transport layer is resumed.
+					failsPrinted = false
+					failsNum = 0
+				}
 				// server responded, check the result code and perform actions accordingly
 				switch result := response.GetResult(); result {
 				case collector.ResultCode_OK:

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -64,7 +64,7 @@ ftgwcxyEq5SkiR+6BCwdzAMqADV37TzXDHLjwSrMIrgLV5xZM20Kk6chxI5QAr/f
 	grpcRetryDelayMultiplier                = 1.5 // backoff multiplier for unsuccessful retries
 	grpcRetryDelayMax                       = 60  // max connection/send retry delay in seconds
 	grpcRedirectMax                         = 20  // max allowed collector redirects
-	grpcRetryTimesWarning                   = 10  // warning logs after this number of retries
+	grpcRetryLogThreshold                   = 10  // log prints after this number of retries (about 56.7s)
 )
 
 // ID of first goroutine that attempts to reconnect a given GRPC client (eventConnection
@@ -133,7 +133,7 @@ func newGRPCReporter() reporter {
 	// service key is required, so bail out if not found
 	serviceKey := os.Getenv("APPOPTICS_SERVICE_KEY")
 	if serviceKey == "" {
-		OboeLog(WARNING, "No service key found, check environment variable APPOPTICS_SERVICE_KEY.")
+		OboeLog(ERROR, "No service key found, check environment variable APPOPTICS_SERVICE_KEY.")
 		return &nullReporter{}
 	}
 
@@ -509,7 +509,7 @@ func (r *grpcReporter) eventRetrySender(
 			if err != nil {
 				// gRPC handles the reconnection automatically.
 				failsNum++
-				if failsNum > grpcRetryTimesWarning && !failsPrinted {
+				if failsNum > grpcRetryLogThreshold && !failsPrinted {
 					OboeLog(WARNING, fmt.Sprintf("Error calling PostEvents(): %v", err))
 					failsPrinted = true
 				} else {
@@ -657,7 +657,7 @@ func (r *grpcReporter) sendMetrics(ready chan bool) {
 		if err != nil {
 			// gRPC handles the reconnection automatically.
 			failsNum++
-			if failsNum > grpcRetryTimesWarning && !failsPrinted {
+			if failsNum > grpcRetryLogThreshold && !failsPrinted {
 				OboeLog(WARNING, fmt.Sprintf("Error calling PostMetrics(): %v", err))
 				failsPrinted = true
 			} else {
@@ -744,7 +744,7 @@ func (r *grpcReporter) getSettings(ready chan bool) {
 		if err != nil {
 			// gRPC handles the reconnection automatically.
 			failsNum++
-			if failsNum > grpcRetryTimesWarning && !failsPrinted {
+			if failsNum > grpcRetryLogThreshold && !failsPrinted {
 				OboeLog(WARNING, fmt.Sprintf("Error calling PostEvents(): %v", err))
 				failsPrinted = true
 			} else {
@@ -908,7 +908,7 @@ func (r *grpcReporter) statusSender() {
 			if err != nil {
 				// gRPC handles the reconnection automatically.
 				failsNum++
-				if failsNum > grpcRetryTimesWarning && !failsPrinted {
+				if failsNum > grpcRetryLogThreshold && !failsPrinted {
 					OboeLog(WARNING, fmt.Sprintf("Error calling PostStatus(): %v", err))
 					failsPrinted = true
 				} else {

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -745,14 +745,14 @@ func (r *grpcReporter) getSettings(ready chan bool) {
 			// gRPC handles the reconnection automatically.
 			failsNum++
 			if failsNum > grpcRetryLogThreshold && !failsPrinted {
-				OboeLog(WARNING, fmt.Sprintf("Error calling PostEvents(): %v", err))
+				OboeLog(WARNING, fmt.Sprintf("Error calling GetSettings(): %v", err))
 				failsPrinted = true
 			} else {
-				OboeLog(DEBUG, fmt.Sprintf("(%v) Error calling PostEvents(): %v", failsNum, err))
+				OboeLog(DEBUG, fmt.Sprintf("(%v) Error calling GetSettings(): %v", failsNum, err))
 			}
 		} else {
 			if failsPrinted {
-				OboeLog(WARNING, fmt.Sprintf("Error recovered in PostEvents()"))
+				OboeLog(WARNING, fmt.Sprintf("Error recovered in GetSettings()"))
 				// Reset the flags here as there might be extra retries even the transport layer is recovered.
 				failsPrinted = false
 				failsNum = 0

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -517,8 +517,8 @@ func (r *grpcReporter) eventRetrySender(
 				}
 			} else {
 				if failsPrinted {
-					OboeLog(WARNING, fmt.Sprintf("Error resumed in PostEvents()"))
-					// Reset the flags here as there might be extra retries even the transport layer is resumed.
+					OboeLog(WARNING, fmt.Sprintf("Error recovered in PostEvents()"))
+					// Reset the flags here as there might be extra retries even the transport layer is recovered.
 					failsPrinted = false
 					failsNum = 0
 				}
@@ -665,8 +665,8 @@ func (r *grpcReporter) sendMetrics(ready chan bool) {
 			}
 		} else {
 			if failsPrinted {
-				OboeLog(WARNING, fmt.Sprintf("Error resumed in PostMetrics()"))
-				// Reset the flags here as there might be extra retries even the transport layer is resumed.
+				OboeLog(WARNING, fmt.Sprintf("Error recovered in PostMetrics()"))
+				// Reset the flags here as there might be extra retries even the transport layer is recovered.
 				failsPrinted = false
 				failsNum = 0
 			}
@@ -752,8 +752,8 @@ func (r *grpcReporter) getSettings(ready chan bool) {
 			}
 		} else {
 			if failsPrinted {
-				OboeLog(WARNING, fmt.Sprintf("Error resumed in PostEvents()"))
-				// Reset the flags here as there might be extra retries even the transport layer is resumed.
+				OboeLog(WARNING, fmt.Sprintf("Error recovered in PostEvents()"))
+				// Reset the flags here as there might be extra retries even the transport layer is recovered.
 				failsPrinted = false
 				failsNum = 0
 			}
@@ -916,8 +916,8 @@ func (r *grpcReporter) statusSender() {
 				}
 			} else {
 				if failsPrinted {
-					OboeLog(WARNING, fmt.Sprintf("Error resumed in PostStatus()"))
-					// Reset the flags here as there might be extra retries even the transport layer is resumed.
+					OboeLog(WARNING, fmt.Sprintf("Error recovered in PostStatus()"))
+					// Reset the flags here as there might be extra retries even the transport layer is recovered.
 					failsPrinted = false
 					failsNum = 0
 				}

--- a/v1/ao/internal/reporter/reporter_test.go
+++ b/v1/ao/internal/reporter/reporter_test.go
@@ -339,7 +339,7 @@ func TestInterruptedGRPCReporter(t *testing.T) {
 
 	s := buf.String()
 	assert.True(t, strings.Contains(s, "Error calling PostEvents"))
-	assert.True(t, strings.Contains(s, "Error resumed in PostEvents"))
+	assert.True(t, strings.Contains(s, "Error recovered in PostEvents"))
 
 	for i := 0; i < len(server.events); i++ {
 		for j := 0; j < len(server.events[i].Messages); j++ {

--- a/v1/ao/internal/reporter/reporter_test.go
+++ b/v1/ao/internal/reporter/reporter_test.go
@@ -10,6 +10,12 @@ import (
 	"testing"
 	"time"
 
+	"strconv"
+
+	"bytes"
+
+	"strings"
+
 	g "github.com/appoptics/appoptics-apm-go/v1/ao/internal/graphtest"
 	pb "github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter/collector"
 	"github.com/stretchr/testify/assert"
@@ -262,9 +268,155 @@ func TestGRPCReporter(t *testing.T) {
 	assert.Equal(t, dec3["Hostname"], cachedHostname)
 	assert.Equal(t, dec2["Distro"], getDistro())
 	assert.Equal(t, dec3["Distro"], getDistro())
+}
 
-	t.Logf("dec1: ", dec1)
-	t.Logf("dec2: ", dec2)
-	t.Logf("dec3: ", dec3)
-	t.Logf("dec4: ", dec4)
+func TestInterruptedGRPCReporter(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer func() {
+		log.SetOutput(os.Stderr)
+	}()
+
+	// start test gRPC server
+	debugLevel = INFO
+	addr := "localhost:4567"
+	// Open it if for verbose print of gRPC
+	//grpclog.SetLogger(log.New(os.Stdout, "grpc: ", log.LstdFlags))
+	server := StartTestGRPCServer(t, addr)
+	time.Sleep(100 * time.Millisecond)
+
+	// set gRPC reporter
+	reportingDisabled = false
+	os.Setenv("APPOPTICS_COLLECTOR", addr)
+	os.Setenv("APPOPTICS_TRUSTEDPATH", testCertFile)
+	oldReporter := globalReporter
+	setGlobalReporter("ssl")
+
+	require.IsType(t, &grpcReporter{}, globalReporter)
+
+	r := globalReporter.(*grpcReporter)
+	var bsonArr []bson.M
+
+	for i := 1; i <= 10; i++ {
+		ctx := newTestContext(t)
+		ev1, _ := ctx.newEvent(LabelInfo, "layer-"+strconv.Itoa(i))
+		assert.NoError(t, r.reportEvent(ctx, ev1))
+		time.Sleep(time.Millisecond * 50)
+	}
+	time.Sleep(time.Second * 10)
+	// stop test reporter
+	server.Stop()
+
+	for i := 0; i < len(server.events); i++ {
+		for j := 0; j < len(server.events[i].Messages); j++ {
+			bs := bson.M{}
+			bson.Unmarshal(server.events[i].Messages[j], &bs)
+			bsonArr = append(bsonArr, bs)
+		}
+	}
+
+	for i := 11; i <= 20; i++ {
+		ctx := newTestContext(t)
+		ev1, _ := ctx.newEvent(LabelInfo, "layer-"+strconv.Itoa(i))
+		assert.NoError(t, r.reportEvent(ctx, ev1))
+		time.Sleep(time.Millisecond * 50)
+	}
+	time.Sleep(time.Second * 60)
+
+	server = StartTestGRPCServer(t, addr)
+	time.Sleep(time.Second * 10)
+
+	for i := 21; i <= 30; i++ {
+		ctx := newTestContext(t)
+		ev1, _ := ctx.newEvent(LabelInfo, "layer-"+strconv.Itoa(i))
+		assert.NoError(t, r.reportEvent(ctx, ev1))
+		time.Sleep(time.Millisecond * 50)
+	}
+
+	time.Sleep(time.Second * 30)
+	globalReporter = oldReporter
+	server.Stop()
+
+	s := buf.String()
+	assert.True(t, strings.Contains(s, "Error calling PostEvents"))
+	assert.True(t, strings.Contains(s, "Error resumed in PostEvents"))
+
+	for i := 0; i < len(server.events); i++ {
+		for j := 0; j < len(server.events[i].Messages); j++ {
+			bs := bson.M{}
+			bson.Unmarshal(server.events[i].Messages[j], &bs)
+			bsonArr = append(bsonArr, bs)
+		}
+	}
+	assert.Equal(t, 30, len(bsonArr))
+
+}
+
+func TestRedirect(t *testing.T) {
+	// start test gRPC server
+	debugLevel = INFO
+
+	addr := "localhost:4567"
+	// Open it if for verbose print of gRPC
+	//grpclog.SetLogger(log.New(os.Stdout, "grpc: ", log.LstdFlags))
+	server := StartTestGRPCServer(t, addr)
+	time.Sleep(100 * time.Millisecond)
+
+	// set gRPC reporter
+	reportingDisabled = false
+	os.Setenv("APPOPTICS_COLLECTOR", addr)
+	os.Setenv("APPOPTICS_TRUSTEDPATH", testCertFile)
+	oldReporter := globalReporter
+	setGlobalReporter("ssl")
+
+	require.IsType(t, &grpcReporter{}, globalReporter)
+
+	r := globalReporter.(*grpcReporter)
+	var bsonArr []bson.M
+
+	for i := 1; i <= 10; i++ {
+		ctx := newTestContext(t)
+		ev1, _ := ctx.newEvent(LabelInfo, "layer-"+strconv.Itoa(i))
+		assert.NoError(t, r.reportEvent(ctx, ev1))
+		time.Sleep(time.Millisecond * 50)
+	}
+	time.Sleep(time.Second * 10)
+	// stop test reporter
+	server.Stop()
+
+	for i := 0; i < len(server.events); i++ {
+		for j := 0; j < len(server.events[i].Messages); j++ {
+			bs := bson.M{}
+			bson.Unmarshal(server.events[i].Messages[j], &bs)
+			bsonArr = append(bsonArr, bs)
+		}
+	}
+
+	addr2 := "localhost:4568"
+	server = StartTestGRPCServer(t, addr2)
+	time.Sleep(time.Second * 10)
+
+	// Call redirect directly
+	r.redirect(r.eventConnection, POSTEVENTS, addr2)
+
+	for i := 11; i <= 20; i++ {
+		ctx := newTestContext(t)
+		ev1, _ := ctx.newEvent(LabelInfo, "layer-"+strconv.Itoa(i))
+		assert.NoError(t, r.reportEvent(ctx, ev1))
+		time.Sleep(time.Millisecond * 50)
+	}
+	time.Sleep(time.Second * 10)
+
+	globalReporter = oldReporter
+	server.Stop()
+
+	for i := 0; i < len(server.events); i++ {
+		for j := 0; j < len(server.events[i].Messages); j++ {
+			bs := bson.M{}
+			bson.Unmarshal(server.events[i].Messages[j], &bs)
+			bsonArr = append(bsonArr, bs)
+		}
+	}
+	assert.Equal(t, 20, len(bsonArr))
+
 }


### PR DESCRIPTION
Pull request for Jira issue AO-8243:
1. It will print an error message when the number of retries to post messages reaches a threshold (10 for now). There will also be a message for recovery then.
2. Removed `redirect` invocations in the error handling of `Post*` as it does nothing helpful.
3. Test cases for the changes