### PR TITLE
AO-8007-Remove the files check for EC2 metadata

### DIFF
--- a/v1/ao/internal/reporter/metrics.go
+++ b/v1/ao/internal/reporter/metrics.go
@@ -430,18 +430,21 @@ func getAWSMeta(cached *string, url string) string {
 		return *cached
 	}
 	// Fetch it from the specified URL if the cache is uninitialized or no cache at all.
-	*cached = ""
+	meta := ""
+	if cached != nil {
+		defer func() { *cached = meta }()
+	}
 	client := http.Client{Timeout: time.Second}
 	resp, err := client.Get(url)
 	if err == nil {
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
 		if err == nil {
-			*cached = string(body)
+			meta = string(body)
 		}
 	}
 
-	return *cached
+	return meta
 }
 
 // gets the AWS instance ID (or empty string if not an AWS instance)

--- a/v1/ao/internal/reporter/metrics.go
+++ b/v1/ao/internal/reporter/metrics.go
@@ -113,7 +113,6 @@ type rateCounts struct{ requested, sampled, limited, traced, through int64 }
 var (
 	cachedDistro          string            // cached distribution name
 	cachedMACAddresses    = "uninitialized" // cached list MAC addresses
-	cachedIsEC2Instance   *bool             // cached EC2 instance check
 	cachedAWSInstanceID   = "uninitialized" // cached EC2 instance ID (if applicable)
 	cachedAWSInstanceZone = "uninitialized" // cached EC2 instance zone (if applicable)
 	cachedContainerID     = "uninitialized" // cached docker container ID (if applicable)
@@ -425,44 +424,34 @@ func getMACAddressList() string {
 	return cachedMACAddresses
 }
 
-// gets the AWS instance ID (or empty string if not an AWS instance)
-func getAWSInstanceID() string {
-	if cachedAWSInstanceID != "uninitialized" {
-		return cachedAWSInstanceID
+// getAWSMeta fetches the metadata from a specific AWS URL and cache it into a provided variable
+func getAWSMeta(cached *string, url string) string {
+	if cached != nil && *cached != "uninitialized" {
+		return *cached
 	}
-
-	cachedAWSInstanceID = ""
+	// Fetch it from the specified URL if the cache is uninitialized or no cache at all.
+	*cached = ""
 	client := http.Client{Timeout: time.Second}
-	resp, err := client.Get(ec2MetadataInstanceIDURL)
+	resp, err := client.Get(url)
 	if err == nil {
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
 		if err == nil {
-			cachedAWSInstanceID = string(body)
+			*cached = string(body)
 		}
 	}
 
-	return cachedAWSInstanceID
+	return *cached
+}
+
+// gets the AWS instance ID (or empty string if not an AWS instance)
+func getAWSInstanceID() string {
+	return getAWSMeta(&cachedAWSInstanceID, ec2MetadataInstanceIDURL)
 }
 
 // gets the AWS instance zone (or empty string if not an AWS instance)
 func getAWSInstanceZone() string {
-	if cachedAWSInstanceZone != "uninitialized" {
-		return cachedAWSInstanceZone
-	}
-
-	cachedAWSInstanceZone = ""
-	client := http.Client{Timeout: time.Second}
-	resp, err := client.Get(ec2MetadataZoneURL)
-	if err == nil {
-		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
-		if err == nil {
-			cachedAWSInstanceZone = string(body)
-		}
-	}
-
-	return cachedAWSInstanceZone
+	return getAWSMeta(&cachedAWSInstanceZone, ec2MetadataZoneURL)
 }
 
 // gets the docker container ID (or empty string if not a docker/ecs container)

--- a/v1/ao/internal/reporter/metrics_test.go
+++ b/v1/ao/internal/reporter/metrics_test.go
@@ -143,7 +143,12 @@ func TestGetAWSMetadata(t *testing.T) {
 
 	id := getAWSInstanceID()
 	assert.Equal(t, id, "i-12345678")
+	assert.Equal(t, "i-12345678", cachedAWSInstanceID)
 	zone := getAWSInstanceZone()
+	assert.Equal(t, zone, "us-east-7")
+	assert.Equal(t, "us-east-7", cachedAWSInstanceZone)
+	// test the helper function
+	zone = getAWSMeta(nil, ec2MetadataZoneURL)
 	assert.Equal(t, zone, "us-east-7")
 }
 

--- a/v1/ao/internal/reporter/metrics_test.go
+++ b/v1/ao/internal/reporter/metrics_test.go
@@ -5,7 +5,6 @@ package reporter
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math"
 	"net"
@@ -115,63 +114,6 @@ func TestAppendMACAddresses(t *testing.T) {
 	} else {
 		assert.Equal(t, 0, len(macs))
 	}
-}
-
-func TestIsEC2Instance(t *testing.T) {
-	file1 := "/tmp/TestIsEC2Instance1"
-	file2 := "/tmp/TestIsEC2Instance2"
-
-	// test with one file that contains garbage
-	ioutil.WriteFile(file1, []byte("garbage"), 0644)
-	assert.False(t, isEC2Instance([]string{file1}))
-	cachedIsEC2Instance = nil
-	os.Remove(file1)
-
-	// test with one file that contains valid EC2 UUID (lowercase)
-	ioutil.WriteFile(file1, []byte("ec2e1916-9099-7caf-fd21-012345abcdef"), 0644)
-	assert.True(t, isEC2Instance([]string{file1}))
-	cachedIsEC2Instance = nil
-	os.Remove(file1)
-
-	// test with one file that contains valid EC2 UUID (uppercase)
-	ioutil.WriteFile(file1, []byte("EC2E1916-9099-7CAF-FD21-01234ABCDEF"), 0644)
-	assert.True(t, isEC2Instance([]string{file1}))
-	cachedIsEC2Instance = nil
-	os.Remove(file1)
-
-	// test with one file that contains invalid EC2 UUID
-	ioutil.WriteFile(file1, []byte("EC3E1916-9099-7CAF-FD21-01234ABCDEF"), 0644)
-	assert.False(t, isEC2Instance([]string{file1}))
-	cachedIsEC2Instance = nil
-	os.Remove(file1)
-
-	// test with one file that contains valid EC2 UUID (lowercase, little endian format)
-	ioutil.WriteFile(file1, []byte("45e12aec-dcd1-b213-94ed-01234abcdef"), 0644)
-	assert.True(t, isEC2Instance([]string{file1}))
-	cachedIsEC2Instance = nil
-	os.Remove(file1)
-
-	// test with one file that contains valid EC2 UUID (uppercase, little endian format)
-	ioutil.WriteFile(file1, []byte("45E12AEC-DCD1-B213-94ED-01234ABCDEF"), 0644)
-	assert.True(t, isEC2Instance([]string{file1}))
-	cachedIsEC2Instance = nil
-	os.Remove(file1)
-
-	// test with two files with the second one containing valid EC2 UUID
-	ioutil.WriteFile(file1, []byte("garbage"), 0644)
-	ioutil.WriteFile(file2, []byte("ec2e1916-9099-7caf-fd21-012345abcdef"), 0644)
-	assert.True(t, isEC2Instance([]string{file1, file2}))
-	cachedIsEC2Instance = nil
-	os.Remove(file1)
-	os.Remove(file2)
-
-	// test with two files with both containing invalid EC2 UUID
-	ioutil.WriteFile(file1, []byte("garbage"), 0644)
-	ioutil.WriteFile(file2, []byte("ec3e1916-9099-7caf-fd21-012345abcdef"), 0644)
-	assert.False(t, isEC2Instance([]string{file1, file2}))
-	cachedIsEC2Instance = nil
-	os.Remove(file1)
-	os.Remove(file2)
 }
 
 func TestGetAWSMetadata(t *testing.T) {

--- a/v1/ao/internal/reporter/metrics_test.go
+++ b/v1/ao/internal/reporter/metrics_test.go
@@ -131,9 +131,6 @@ func TestGetAWSMetadata(t *testing.T) {
 
 	s := &http.Server{Addr: addr, Handler: sm}
 	// change EC2 MD URLs
-	origIsEC2 := cachedIsEC2Instance
-	True := true
-	cachedIsEC2Instance = &True
 	ec2MetadataInstanceIDURL = strings.Replace(ec2MetadataInstanceIDURL, "169.254.169.254", addr, 1)
 	ec2MetadataZoneURL = strings.Replace(ec2MetadataZoneURL, "169.254.169.254", addr, 1)
 	go s.Serve(ln)
@@ -141,7 +138,6 @@ func TestGetAWSMetadata(t *testing.T) {
 		ln.Close()
 		ec2MetadataInstanceIDURL = strings.Replace(ec2MetadataInstanceIDURL, addr, "169.254.169.254", 1)
 		ec2MetadataZoneURL = strings.Replace(ec2MetadataZoneURL, addr, "169.254.169.254", 1)
-		cachedIsEC2Instance = origIsEC2
 	}()
 	time.Sleep(50 * time.Millisecond)
 


### PR DESCRIPTION
This pull request is for the Jira task: https://swicloud.atlassian.net/browse/AO-8007

Remove the files check (to make sure it's an EC2 instance) before we fetch the EC2 metadata.
1. Removed `isEC2Instance` and its test cases
2. Removed the global variable `cachedIsEC2Instance`
3. Created a helper function to cover both `getAWSInstanceID` and `getAWSInstanceZone`
4. Added test cases in `TestGetAWSMetadata`