### PR TITLE
AO-7051 Custom Transaction Name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   global:
     - GO15VENDOREXPERIMENT=1
     - APPOPTICS_DEBUG_LEVEL=1
+    - APPOPTICS_SERVICE_KEY=123abc:Go
         
 install:
   - go get golang.org/x/tools/cmd/cover

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ These environment variables may be set:
 |APPOPTICS_COLLECTOR_UDP|No|127.0.0.1:7831|UDP collector endpoint address and port (only used if APPOPTICS_REPORTER = udp).|
 |APPOPTICS_TRUSTEDPATH|No||Path to the certificate used to verify the collector endpoint.|
 |APPOPTICS_INSECURE_SKIP_VERIFY|No|false|Skip verification of the collector endpoint. Possible values: true, false|
+|APPOPTICS_PREPEND_DOMAIN|No|false|Prepend the domain name to the transaction name. Possible values: true, false|
 
 
 ## Help and examples

--- a/examples/gin_app/gin_middleware.go
+++ b/examples/gin_app/gin_middleware.go
@@ -11,14 +11,14 @@ import (
 
 const (
 	ginContextKey = "AppOptics"
-	ginLayerName  = "gin"
+	ginSpanName   = "gin"
 )
 
 func tracer() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		t, w, _ := ao.TraceFromHTTPRequestResponse("gin", c.Writer, c.Request)
+		t, w, _ := ao.TraceFromHTTPRequestResponse(ginSpanName, c.Writer, c.Request)
 		c.Writer = &ginResponseWriter{w.(*ao.HTTPResponseWriter), c.Writer}
-		t.SetControllerAction(ginLayerName, c.HandlerName())
+		t.SetTransactionName(c.HandlerName())
 		defer t.End()
 		// create a context.Context and bind it to the gin.Context
 		c.Set(ginContextKey, ao.NewContext(context.Background(), t))

--- a/v1/ao/http_instrumentation.go
+++ b/v1/ao/http_instrumentation.go
@@ -140,6 +140,8 @@ func traceFromHTTPRequest(spanName string, r *http.Request, isNewcontext bool) T
 	})
 	// set the start time and method for metrics collection
 	t.SetMethod(r.Method)
+	t.SetURL(r.URL.String())
+	t.SetHost(r.Host)
 	if isNewcontext {
 		t.SetStartTime(time.Now())
 	}

--- a/v1/ao/http_instrumentation.go
+++ b/v1/ao/http_instrumentation.go
@@ -133,17 +133,18 @@ func traceFromHTTPRequest(spanName string, r *http.Request, isNewcontext bool) T
 		return KVMap{
 			"Method":       r.Method,
 			"HTTP-Host":    r.Host,
-			"URL":          r.URL.Path,
+			"URL":          r.URL.EscapedPath(),
 			"Remote-Host":  r.RemoteAddr,
 			"Query-String": r.URL.RawQuery,
 		}
 	})
 	// set the start time and method for metrics collection
 	t.SetMethod(r.Method)
-	t.SetURL(r.URL.String())
+	t.SetPath(r.URL.EscapedPath())
 	t.SetHost(r.Host)
-	if isNewcontext {
-		t.SetStartTime(time.Now())
+	// Clear the start time if it is not a new context
+	if !isNewcontext {
+		t.SetStartTime(time.Time{})
 	}
 	// update incoming metadata in request headers for any downstream readers
 	r.Header.Set(HTTPHeaderName, t.MetadataString())

--- a/v1/ao/http_instrumentation.go
+++ b/v1/ao/http_instrumentation.go
@@ -66,14 +66,17 @@ func TraceFromHTTPRequestResponse(spanName string, w http.ResponseWriter, r *htt
 
 	// determine if this is a new context, if so set flag isNewcontext to start a new HTTP Span
 	isNewcontext := false
-	ctx := r.Context()
-	if b, ok := ctx.Value(httpSpanKey).(bool); !ok || !b {
+	if b, ok := r.Context().Value(httpSpanKey).(bool); !ok || !b {
 		// save KV to ensure future calls won't treat as new context
-		r = r.WithContext(context.WithValue(ctx, httpSpanKey, true))
+		r = r.WithContext(context.WithValue(r.Context(), httpSpanKey, true))
 		isNewcontext = true
 	}
 
 	t := traceFromHTTPRequest(spanName, r, isNewcontext)
+
+	// Associate the trace with http.Request to expose it to the handler
+	r = r.WithContext(NewContext(r.Context(), t))
+
 	wrapper := newResponseWriter(w, t) // wrap writer with response-observing writer
 	return t, wrapper, r
 }

--- a/v1/ao/http_instrumentation_oboe_test.go
+++ b/v1/ao/http_instrumentation_oboe_test.go
@@ -1,0 +1,33 @@
+// +build !disable_tracing
+// Copyright (C) 2016 Librato, Inc. All rights reserved.
+
+package ao_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	g "github.com/appoptics/appoptics-apm-go/v1/ao/internal/graphtest"
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomTransactionNameWithDomain(t *testing.T) {
+	os.Setenv("APPOPTICS_PREPEND_DOMAIN", "true")
+
+	r := reporter.SetTestReporter() // set up test reporter
+	httpTestWithEndpoint(handler200, "http://test.com/hello world/one/two/three?testq")
+	r.Close(2)
+	g.AssertGraph(t, r.EventBufs, 2, g.AssertNodeMap{
+		// entry event should have no edges
+		{"http.HandlerFunc", "entry"}: {Edges: g.Edges{}, Callback: func(n g.Node) {
+			assert.Equal(t, "test.com", n.Map["HTTP-Host"])
+		}},
+		{"http.HandlerFunc", "exit"}: {Edges: g.Edges{{"http.HandlerFunc", "entry"}}, Callback: func(n g.Node) {
+			// assert that response X-Trace header matches trace exit event
+			assert.True(t, strings.HasPrefix(n.Map["TransactionName"].(string), "test.com/final-my-custom-transaction-name"))
+		}},
+	})
+	os.Unsetenv("APPOPTICS_PREPEND_DOMAIN")
+}

--- a/v1/ao/http_instrumentation_test.go
+++ b/v1/ao/http_instrumentation_test.go
@@ -16,8 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"os"
-
 	"github.com/appoptics/appoptics-apm-go/v1/ao"
 	g "github.com/appoptics/appoptics-apm-go/v1/ao/internal/graphtest"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
@@ -129,26 +127,6 @@ func TestHTTPHandler200(t *testing.T) {
 			assert.True(t, reporter.ValidMetadata(response.Body.String()))
 		}},
 	})
-}
-
-func TestCustomTransactionNameWithDomain(t *testing.T) {
-	os.Setenv("APPOPTICS_PREPEND_DOMAIN", "true")
-
-	r := reporter.SetTestReporter() // set up test reporter
-	httpTestWithEndpoint(handler200, "http://test.com/hello world/one/two/three?testq")
-
-	r.Close(2)
-	g.AssertGraph(t, r.EventBufs, 2, g.AssertNodeMap{
-		// entry event should have no edges
-		{"http.HandlerFunc", "entry"}: {Edges: g.Edges{}, Callback: func(n g.Node) {
-			assert.Equal(t, "test.com", n.Map["HTTP-Host"])
-		}},
-		{"http.HandlerFunc", "exit"}: {Edges: g.Edges{{"http.HandlerFunc", "entry"}}, Callback: func(n g.Node) {
-			// assert that response X-Trace header matches trace exit event
-			assert.True(t, strings.HasPrefix(n.Map["TransactionName"].(string), "test.com/final-my-custom-transaction-name"))
-		}},
-	})
-	os.Unsetenv("APPOPTICS_PREPEND_DOMAIN")
 }
 
 func TestHTTPHandlerNoTrace(t *testing.T) {

--- a/v1/ao/http_instrumentation_test.go
+++ b/v1/ao/http_instrumentation_test.go
@@ -130,7 +130,7 @@ func TestHTTPSpan(t *testing.T) {
 	m, ok = r.SpanMessages[2].(*reporter.HTTPSpanMessage)
 	assert.True(t, ok)
 	assert.Equal(t, "ao_test.handlerDelay200", m.Transaction)
-	assert.Equal(t, "", m.URL)
+	assert.Equal(t, "http://test.com/hello?testq", m.URL)
 	assert.Equal(t, 200, m.Status)
 	assert.Equal(t, "GET", m.Method)
 	assert.False(t, m.HasError)

--- a/v1/ao/http_instrumentation_test.go
+++ b/v1/ao/http_instrumentation_test.go
@@ -56,8 +56,7 @@ func checkAOContextAndSetCustomTxnName(w http.ResponseWriter, r *http.Request) {
 		}(i)
 	}
 	time.Sleep(10 * time.Millisecond)
-	old, _ := ao.GetTransactionName(r.Context())
-	ao.SetTransactionName(r.Context(), "final-"+old)
+	ao.SetTransactionName(r.Context(), "final-"+ao.GetTransactionName(r.Context()))
 	xtrace = t.MetadataString()
 }
 

--- a/v1/ao/http_instrumentation_test.go
+++ b/v1/ao/http_instrumentation_test.go
@@ -91,6 +91,7 @@ func TestHTTPHandler200(t *testing.T) {
 			assert.EqualValues(t, 200, n.Map["Status"])
 			assert.Equal(t, "ao_test", n.Map["Controller"])
 			assert.Equal(t, "handler200", n.Map["Action"])
+			assert.Equal(t, "ao_test.handler200", n.Map["TransactionName"])
 		}},
 	})
 }
@@ -130,7 +131,7 @@ func TestHTTPSpan(t *testing.T) {
 	m, ok = r.SpanMessages[2].(*reporter.HTTPSpanMessage)
 	assert.True(t, ok)
 	assert.Equal(t, "ao_test.handlerDelay200", m.Transaction)
-	assert.Equal(t, "http://test.com/hello?testq", m.URL)
+	assert.Equal(t, "/hello", m.Path)
 	assert.Equal(t, 200, m.Status)
 	assert.Equal(t, "GET", m.Method)
 	assert.False(t, m.HasError)

--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -42,7 +42,7 @@ type oboeMetadata struct {
 
 type oboeContext struct {
 	metadata oboeMetadata
-	txCtx    *transactionContext
+	txCtx    transactionContext
 }
 
 type transactionContext struct {
@@ -256,6 +256,7 @@ type Context interface {
 	IsSampled() bool
 	SetSampled(trace bool)
 	SetTransactionName(name string)
+	GetTransactionName() string
 	MetadataString() string
 	NewEvent(label Label, layer string, addCtxEdge bool) Event
 	GetVersion() uint8
@@ -281,6 +282,7 @@ func (e *nullContext) Copy() Context                                         { r
 func (e *nullContext) IsSampled() bool                                       { return false }
 func (e *nullContext) SetSampled(trace bool)                                 {}
 func (e *nullContext) SetTransactionName(name string)                        {}
+func (e *nullContext) GetTransactionName() string                            { return "" }
 func (e *nullContext) MetadataString() string                                { return "" }
 func (e *nullContext) NewEvent(l Label, y string, g bool) Event              { return &nullEvent{} }
 func (e *nullContext) GetVersion() uint8                                     { return 0 }
@@ -378,6 +380,10 @@ func (ctx *oboeContext) SetSampled(trace bool) {
 
 func (ctx *oboeContext) SetTransactionName(name string) {
 	ctx.txCtx.name = name
+}
+
+func (ctx *oboeContext) GetTransactionName() string {
+	return ctx.txCtx.name
 }
 
 func (ctx *oboeContext) newEvent(label Label, layer string) (*event, error) {

--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"log"
 	"strings"
+	"sync"
 )
 
 const (
@@ -47,6 +48,7 @@ type oboeContext struct {
 
 type transactionContext struct {
 	name string
+	sync.RWMutex
 }
 
 // ValidMetadata checks if a metadata string is valid.
@@ -379,10 +381,14 @@ func (ctx *oboeContext) SetSampled(trace bool) {
 }
 
 func (ctx *oboeContext) SetTransactionName(name string) {
+	ctx.txCtx.Lock()
+	defer ctx.txCtx.Unlock()
 	ctx.txCtx.name = name
 }
 
 func (ctx *oboeContext) GetTransactionName() string {
+	ctx.txCtx.RLock()
+	defer ctx.txCtx.RUnlock()
 	return ctx.txCtx.name
 }
 

--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -42,7 +42,7 @@ type oboeMetadata struct {
 
 type oboeContext struct {
 	metadata oboeMetadata
-	txCtx    transactionContext
+	txCtx    *transactionContext
 }
 
 type transactionContext struct {
@@ -294,7 +294,7 @@ func NewNullContext() Context { return &nullContext{} }
 
 // newContext allocates a context with random metadata (for a new trace).
 func newContext(sampled bool) Context {
-	ctx := &oboeContext{}
+	ctx := &oboeContext{txCtx: &transactionContext{}}
 	ctx.metadata.Init()
 	if err := ctx.metadata.SetRandom(); err != nil {
 		if debugLog {
@@ -307,7 +307,7 @@ func newContext(sampled bool) Context {
 }
 
 func newContextFromMetadataString(mdstr string) (*oboeContext, error) {
-	ctx := &oboeContext{}
+	ctx := &oboeContext{txCtx: &transactionContext{}}
 	ctx.metadata.Init()
 	err := ctx.metadata.FromString(mdstr)
 	return ctx, err

--- a/v1/ao/internal/reporter/context_test.go
+++ b/v1/ao/internal/reporter/context_test.go
@@ -195,6 +195,9 @@ func TestMetadataRandom(t *testing.T) {
 func newTestContext(t *testing.T) *oboeContext {
 	ctx := newContext(true)
 	assert.True(t, ctx.IsSampled())
+	assert.Equal(t, "", ctx.GetTransactionName())
+	ctx.SetTransactionName("my-custom-transaction-name")
+	assert.Equal(t, "my-custom-transaction-name", ctx.GetTransactionName())
 	assert.IsType(t, ctx, &oboeContext{})
 	return ctx.(*oboeContext)
 }

--- a/v1/ao/internal/reporter/context_test.go
+++ b/v1/ao/internal/reporter/context_test.go
@@ -110,7 +110,7 @@ func TestMetadata(t *testing.T) {
 	assert.NoError(t, err)     // no error
 
 	// context.String()
-	ctx := &oboeContext{md2}
+	ctx := &oboeContext{metadata: md2}
 	assert.Equal(t, md1Str, ctx.MetadataString())
 	nctx := &nullContext{}
 	assert.Equal(t, "", nctx.MetadataString())
@@ -134,7 +134,7 @@ func TestMetadata(t *testing.T) {
 	// isSampled()
 	var md3 oboeMetadata
 	md3.FromString(md1Str)
-	ctx3 := &oboeContext{md3}
+	ctx3 := &oboeContext{metadata: md3}
 	ctx3.SetSampled(true)
 	assert.True(t, ctx3.IsSampled())
 	assert.Equal(t, "01", ctx3.MetadataString()[58:])

--- a/v1/ao/internal/reporter/event.go
+++ b/v1/ao/internal/reporter/event.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log"
 	"math"
 )
 
@@ -263,7 +262,7 @@ func (e *event) AddKV(key, value interface{}) error {
 	default:
 		// silently skip unsupported value type
 		if debugLog {
-			log.Printf("Unrecognized Event key %v val %v", k, v)
+			OboeLog(DEBUG, "Unrecognized Event key %v val %v", k, v)
 		}
 	}
 	return nil

--- a/v1/ao/internal/reporter/metrics.go
+++ b/v1/ao/internal/reporter/metrics.go
@@ -68,6 +68,7 @@ type HTTPSpanMessage struct {
 	Transaction string // transaction name (e.g. controller.action)
 	URL         string // the raw url which will be processed and used as transaction (if Transaction is empty)
 	Status      int    // HTTP status code (e.g. 200, 500, ...)
+	Host        string // HTTP-Host
 	Method      string // HTTP method (e.g. GET, POST, ...)
 }
 
@@ -557,6 +558,9 @@ func addMetricsValue(bbuf *bsonBuffer, index *int, name string, value interface{
 // e.g. https://github.com/appoptics/appoptics-apm-go/blob/metrics becomes /appoptics/appoptics-apm-go
 func GetTransactionFromURL(url string) string {
 	matches := metricsHTTPMeasurements.urlRegex.FindStringSubmatch(url)
+	if len(matches) < 6 {
+		return ""
+	}
 	var ret string
 	if matches[3] != "" {
 		ret += "/" + matches[3]

--- a/v1/ao/internal/reporter/metrics_test.go
+++ b/v1/ao/internal/reporter/metrics_test.go
@@ -234,7 +234,7 @@ func TestGetTransactionFromURL(t *testing.T) {
 	}
 
 	for _, r := range test {
-		assert.Equal(t, r.transaction, getTransactionFromURL(r.url), "url: "+r.url)
+		assert.Equal(t, r.transaction, GetTransactionFromURL(r.url), "url: "+r.url)
 	}
 }
 

--- a/v1/ao/internal/reporter/metrics_test.go
+++ b/v1/ao/internal/reporter/metrics_test.go
@@ -208,33 +208,29 @@ func TestGetTransactionFromURL(t *testing.T) {
 	}
 	var test = []record{
 		{
-			"https://github.com/appoptics/appoptics-apm-go/blob/metrics/reporter.go#L867",
+			"/appoptics/appoptics-apm-go/blob/metrics/reporter.go#L867",
 			"/appoptics/appoptics-apm-go",
 		},
 		{
-			"http://github.com/librato",
+			"/librato",
 			"/librato",
 		},
 		{
-			"http://github.com",
+			"",
 			"/",
 		},
 		{
-			"github.com/appoptics/appoptics-apm-go/blob",
+			"/appoptics/appoptics-apm-go/blob",
 			"/appoptics/appoptics-apm-go",
 		},
 		{
-			"github.com:8080/appoptics/appoptics-apm-go/blob",
+			"/appoptics/appoptics-apm-go/blob",
 			"/appoptics/appoptics-apm-go",
-		},
-		{
-			" ",
-			"/",
 		},
 	}
 
 	for _, r := range test {
-		assert.Equal(t, r.transaction, GetTransactionFromURL(r.url), "url: "+r.url)
+		assert.Equal(t, r.transaction, GetTransactionFromPath(r.url), "url: "+r.url)
 	}
 }
 

--- a/v1/ao/internal/reporter/metrics_test.go
+++ b/v1/ao/internal/reporter/metrics_test.go
@@ -228,6 +228,14 @@ func TestGetTransactionFromURL(t *testing.T) {
 			"/appoptics/appoptics-apm-go/blob",
 			"/appoptics/appoptics-apm-go",
 		},
+		{
+			"http://test.com/appoptics/appoptics-apm-go/blob",
+			"http://test.com",
+		},
+		{
+			"$%@#%/$%#^*$&/ 1234 4!@ 145412! / 13%1 /14%!$#%^#%& ? 6/``/ ?dfgdf",
+			"$%@#%/$%#^*$&/ 1234 4!@ 145412! ",
+		},
 	}
 
 	for _, r := range test {

--- a/v1/ao/internal/reporter/metrics_test.go
+++ b/v1/ao/internal/reporter/metrics_test.go
@@ -249,7 +249,7 @@ func TestIsWithinLimit(t *testing.T) {
 
 func TestRecordMeasurement(t *testing.T) {
 	var me = &measurements{
-		measurements: make(map[string]*measurement),
+		measurements: make(map[string]*Measurement),
 	}
 
 	t1 := make(map[string]string)
@@ -259,21 +259,21 @@ func TestRecordMeasurement(t *testing.T) {
 	recordMeasurement(me, "name1", &t1, 222, 1, false)
 	assert.NotNil(t, me.measurements["name1&false&t1:tag1&t2:tag2&"])
 	m := me.measurements["name1&false&t1:tag1&t2:tag2&"]
-	assert.Equal(t, "tag1", m.tags["t1"])
-	assert.Equal(t, "tag2", m.tags["t2"])
-	assert.Equal(t, 333.11, m.sum)
-	assert.Equal(t, 2, m.count)
-	assert.False(t, m.reportSum)
+	assert.Equal(t, "tag1", m.Tags["t1"])
+	assert.Equal(t, "tag2", m.Tags["t2"])
+	assert.Equal(t, 333.11, m.Sum)
+	assert.Equal(t, 2, m.Count)
+	assert.False(t, m.ReportSum)
 
 	t2 := make(map[string]string)
 	t2["t3"] = "tag3"
 	recordMeasurement(me, "name2", &t2, 123.456, 3, true)
 	assert.NotNil(t, me.measurements["name2&true&t3:tag3&"])
 	m = me.measurements["name2&true&t3:tag3&"]
-	assert.Equal(t, "tag3", m.tags["t3"])
-	assert.Equal(t, 123.456, m.sum)
-	assert.Equal(t, 3, m.count)
-	assert.True(t, m.reportSum)
+	assert.Equal(t, "tag3", m.Tags["t3"])
+	assert.Equal(t, 123.456, m.Sum)
+	assert.Equal(t, 3, m.Count)
+	assert.True(t, m.ReportSum)
 }
 
 func TestRecordHistogram(t *testing.T) {
@@ -317,19 +317,19 @@ func TestAddMeasurementToBSON(t *testing.T) {
 	tags2 := make(map[string]string)
 	tags2[veryLongTagName] = veryLongTagValue
 
-	measurement1 := &measurement{
-		name:      "name1",
-		tags:      tags1,
-		count:     45,
-		sum:       592.42,
-		reportSum: false,
+	measurement1 := &Measurement{
+		Name:      "name1",
+		Tags:      tags1,
+		Count:     45,
+		Sum:       592.42,
+		ReportSum: false,
 	}
-	measurement2 := &measurement{
-		name:      "name2",
-		tags:      tags2,
-		count:     777,
-		sum:       6530.3,
-		reportSum: true,
+	measurement2 := &Measurement{
+		Name:      "name2",
+		Tags:      tags2,
+		Count:     777,
+		Sum:       6530.3,
+		ReportSum: true,
 	}
 
 	index := 0

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -86,6 +86,12 @@ func readEnvSettings() {
 			OboeLog(WARNING, fmt.Sprintf("invalid debug level: %s", level))
 		}
 	}
+
+	// Prepend the domain name onto transaction names
+	prepend := os.Getenv("APPOPTICS_PREPEND_DOMAIN")
+	if strings.ToLower(prepend) == "true" {
+		prependDomainForTransactionName = true
+	}
 }
 
 func sendInitMessage() {

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -91,6 +91,8 @@ func readEnvSettings() {
 	prepend := os.Getenv("APPOPTICS_PREPEND_DOMAIN")
 	if strings.ToLower(prepend) == "true" {
 		prependDomainForTransactionName = true
+	} else {
+		prependDomainForTransactionName = false
 	}
 }
 

--- a/v1/ao/internal/reporter/reporter.go
+++ b/v1/ao/internal/reporter/reporter.go
@@ -18,7 +18,7 @@ type reporter interface {
 	// called when a status (e.g. __Init message) should be reported
 	reportStatus(ctx *oboeContext, e *event) error
 	// called when a Span message should be reported
-	reportSpan(span *SpanMessage) error
+	reportSpan(span SpanMessage) error
 }
 
 // currently used reporter
@@ -41,7 +41,7 @@ type nullReporter struct{}
 
 func (r *nullReporter) reportEvent(ctx *oboeContext, e *event) error  { return nil }
 func (r *nullReporter) reportStatus(ctx *oboeContext, e *event) error { return nil }
-func (r *nullReporter) reportSpan(span *SpanMessage) error            { return nil }
+func (r *nullReporter) reportSpan(span SpanMessage) error             { return nil }
 
 // init() is called only once on program startup. Here we create the reporter
 // that will be used throughout the runtime of the app. Default is 'ssl' but
@@ -69,7 +69,7 @@ func setGlobalReporter(reporterType string) {
 //
 // returns	error if channel is full
 func ReportSpan(span SpanMessage) error {
-	return globalReporter.reportSpan(&span)
+	return globalReporter.reportSpan(span)
 }
 
 // cache hostname

--- a/v1/ao/internal/reporter/reporter.go
+++ b/v1/ao/internal/reporter/reporter.go
@@ -35,9 +35,12 @@ var cachedPid = os.Getpid()
 
 // for hostname alias
 var configuredHostname string
+var prependDomainForTransactionName bool
 
 // a noop reporter
 type nullReporter struct{}
+
+func NeedPrependDomain() bool { return prependDomainForTransactionName }
 
 func (r *nullReporter) reportEvent(ctx *oboeContext, e *event) error  { return nil }
 func (r *nullReporter) reportStatus(ctx *oboeContext, e *event) error { return nil }

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -140,11 +140,6 @@ func newGRPCReporter() reporter {
 	// see if a hostname alias is configured
 	configuredHostname = os.Getenv("APPOPTICS_HOSTNAME_ALIAS")
 
-	prepend := os.Getenv("APPOPTICS_PREPEND_DOMAIN")
-	if strings.ToLower(prepend) == "true" {
-		prependDomainForTransactionName = true
-	}
-
 	// collector address override
 	collectorAddress := os.Getenv("APPOPTICS_COLLECTOR")
 	if collectorAddress == "" {

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -905,9 +905,9 @@ func (r *grpcReporter) statusSender() {
 // span		span message to be put on the channel
 //
 // returns	error if channel is full
-func (r *grpcReporter) reportSpan(span *SpanMessage) error {
+func (r *grpcReporter) reportSpan(span SpanMessage) error {
 	select {
-	case r.spanMessages <- *span:
+	case r.spanMessages <- span:
 		return nil
 	default:
 		return errors.New("Span message queue is full")

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -139,6 +139,11 @@ func newGRPCReporter() reporter {
 	// see if a hostname alias is configured
 	configuredHostname = os.Getenv("APPOPTICS_HOSTNAME_ALIAS")
 
+	prepend := os.Getenv("APPOPTICS_PREPEND_DOMAIN")
+	if strings.ToLower(prepend) == "true" {
+		prependDomainForTransactionName = true
+	}
+
 	// collector address override
 	collectorAddress := os.Getenv("APPOPTICS_COLLECTOR")
 	if collectorAddress == "" {

--- a/v1/ao/internal/reporter/reporter_test.go
+++ b/v1/ao/internal/reporter/reporter_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
@@ -80,6 +81,29 @@ func TestReportEvent(t *testing.T) {
 	g.AssertGraph(t, r.EventBufs, 1, g.AssertNodeMap{
 		{"go_test", "exit"}: {},
 	})
+}
+
+func TestReportMetric(t *testing.T) {
+	r := SetTestReporter()
+	spanMsg := &HTTPSpanMessage{
+		BaseSpanMessage: BaseSpanMessage{
+			Duration: time.Second,
+			HasError: false,
+		},
+		Transaction: "tname",
+		URL:         "/path/to/url",
+		Status:      203,
+		Method:      "HEAD",
+	}
+	err := ReportSpan(spanMsg)
+	assert.NoError(t, err)
+	r.Close(1)
+	assert.Len(t, r.SpanMessages, 1)
+	sp, ok := r.SpanMessages[0].(*HTTPSpanMessage)
+	require.True(t, ok)
+	require.NotNil(t, sp)
+	assert.True(t, reflect.DeepEqual(spanMsg, sp))
+	//sp.process()
 }
 
 // test behavior of the TestReporter

--- a/v1/ao/internal/reporter/reporter_test.go
+++ b/v1/ao/internal/reporter/reporter_test.go
@@ -91,7 +91,7 @@ func TestReportMetric(t *testing.T) {
 			HasError: false,
 		},
 		Transaction: "tname",
-		URL:         "/path/to/url",
+		Path:        "/path/to/url",
 		Status:      203,
 		Method:      "HEAD",
 	}

--- a/v1/ao/internal/reporter/reporter_test.go
+++ b/v1/ao/internal/reporter/reporter_test.go
@@ -109,7 +109,6 @@ func TestReportMetric(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, sp)
 	assert.True(t, reflect.DeepEqual(spanMsg, sp))
-	//sp.process()
 }
 
 // test behavior of the TestReporter

--- a/v1/ao/internal/reporter/reporter_udp.go
+++ b/v1/ao/internal/reporter/reporter_udp.go
@@ -63,11 +63,11 @@ func (r *udpReporter) reportStatus(ctx *oboeContext, e *event) error {
 	return r.report(ctx, e)
 }
 
-func (r *udpReporter) reportSpan(span *SpanMessage) error {
-	s := (*span).(*HttpSpanMessage)
+func (r *udpReporter) reportSpan(span SpanMessage) error {
+	s := span.(*HTTPSpanMessage)
 	bbuf := NewBsonBuffer()
 	bsonAppendString(bbuf, "transaction", s.Transaction)
-	bsonAppendString(bbuf, "url", s.Url)
+	bsonAppendString(bbuf, "url", s.URL)
 	bsonAppendInt(bbuf, "status", s.Status)
 	bsonAppendString(bbuf, "method", s.Method)
 	bsonAppendBool(bbuf, "hasError", s.HasError)

--- a/v1/ao/internal/reporter/reporter_udp.go
+++ b/v1/ao/internal/reporter/reporter_udp.go
@@ -67,7 +67,7 @@ func (r *udpReporter) reportSpan(span SpanMessage) error {
 	s := span.(*HTTPSpanMessage)
 	bbuf := NewBsonBuffer()
 	bsonAppendString(bbuf, "transaction", s.Transaction)
-	bsonAppendString(bbuf, "url", s.URL)
+	bsonAppendString(bbuf, "url", s.Path)
 	bsonAppendInt(bbuf, "status", s.Status)
 	bsonAppendString(bbuf, "method", s.Method)
 	bsonAppendBool(bbuf, "hasError", s.HasError)

--- a/v1/ao/internal/reporter/test_reporter.go
+++ b/v1/ao/internal/reporter/test_reporter.go
@@ -169,11 +169,11 @@ func (r *TestReporter) reportStatus(ctx *oboeContext, e *event) error {
 	return r.report(ctx, e)
 }
 
-func (r *TestReporter) reportSpan(span *SpanMessage) error {
-	s := (*span).(*HttpSpanMessage)
+func (r *TestReporter) reportSpan(span SpanMessage) error {
+	s := span.(*HTTPSpanMessage)
 	bbuf := NewBsonBuffer()
 	bsonAppendString(bbuf, "transaction", s.Transaction)
-	bsonAppendString(bbuf, "url", s.Url)
+	bsonAppendString(bbuf, "url", s.URL)
 	bsonAppendInt(bbuf, "status", s.Status)
 	bsonAppendString(bbuf, "method", s.Method)
 	bsonAppendBool(bbuf, "hasError", s.HasError)

--- a/v1/ao/internal/reporter/test_reporter.go
+++ b/v1/ao/internal/reporter/test_reporter.go
@@ -13,17 +13,18 @@ import (
 // TestReporter appends reported events to Bufs if ShouldTrace is true.
 type TestReporter struct {
 	EventBufs             [][]byte
-	StatusBufs            [][]byte
+	SpanMessages          []SpanMessage
 	ShouldTrace           bool
 	ShouldError           bool
 	UseSettings           bool
 	DisableDefaultSetting bool
+	CaptureMetrics        bool
 	ErrorEvents           map[int]bool // whether to drop an event
 	eventCount            int64
 	done                  chan int
 	wg                    sync.WaitGroup
 	eventChan             chan []byte
-	statusChan            chan []byte
+	spanMsgChan           chan SpanMessage
 	Timeout               time.Duration
 }
 
@@ -75,7 +76,7 @@ func SetTestReporter(options ...TestReporterOption) *TestReporter {
 		Timeout:     defaultTestReporterTimeout,
 		done:        make(chan int),
 		eventChan:   make(chan []byte),
-		statusChan:  make(chan []byte),
+		spanMsgChan: make(chan SpanMessage),
 	}
 	for _, option := range options {
 		option(r)
@@ -105,7 +106,7 @@ func (r *TestReporter) resultWriter() {
 	for {
 		select {
 		case numBufs = <-r.done:
-			if len(r.EventBufs)+len(r.StatusBufs) >= numBufs {
+			if len(r.EventBufs)+len(r.SpanMessages) >= numBufs {
 				r.wg.Done()
 				return
 			}
@@ -115,13 +116,13 @@ func (r *TestReporter) resultWriter() {
 			return
 		case buf := <-r.eventChan:
 			r.EventBufs = append(r.EventBufs, buf)
-			if r.done == nil && len(r.EventBufs)+len(r.StatusBufs) >= numBufs {
+			if r.done == nil && len(r.EventBufs)+len(r.SpanMessages) >= numBufs {
 				r.wg.Done()
 				return
 			}
-		case buf := <-r.statusChan:
-			r.StatusBufs = append(r.StatusBufs, buf)
-			if r.done == nil && len(r.EventBufs)+len(r.StatusBufs) >= numBufs {
+		case buf := <-r.spanMsgChan:
+			r.SpanMessages = append(r.SpanMessages, buf)
+			if r.done == nil && len(r.EventBufs)+len(r.SpanMessages) >= numBufs {
 				r.wg.Done()
 				return
 			}
@@ -136,8 +137,9 @@ func (r *TestReporter) Close(numBufs int) {
 	// wait for reader goroutine to receive numBufs events, or timeout.
 	r.wg.Wait()
 	close(r.eventChan)
-	if len(r.EventBufs) < numBufs {
-		log.Printf("# FIX: TestReporter.Close() waited for %d events, got %d", numBufs, len(r.EventBufs))
+	received := len(r.EventBufs) + len(r.SpanMessages)
+	if received < numBufs {
+		log.Printf("# FIX: TestReporter.Close() waited for %d events, got %d", numBufs, received)
 	}
 	usingTestReporter = false
 	if _, ok := oldReporter.(*nullReporter); !ok {
@@ -170,16 +172,7 @@ func (r *TestReporter) reportStatus(ctx *oboeContext, e *event) error {
 }
 
 func (r *TestReporter) reportSpan(span SpanMessage) error {
-	s := span.(*HTTPSpanMessage)
-	bbuf := NewBsonBuffer()
-	bsonAppendString(bbuf, "transaction", s.Transaction)
-	bsonAppendString(bbuf, "url", s.URL)
-	bsonAppendInt(bbuf, "status", s.Status)
-	bsonAppendString(bbuf, "method", s.Method)
-	bsonAppendBool(bbuf, "hasError", s.HasError)
-	bsonAppendInt64(bbuf, "duration", s.Duration.Nanoseconds())
-	bsonBufferFinish(bbuf)
-	r.statusChan <- bbuf.buf
+	r.spanMsgChan <- span
 	return nil
 }
 

--- a/v1/ao/internal/reporter/utils.go
+++ b/v1/ao/internal/reporter/utils.go
@@ -47,8 +47,8 @@ var dbgLevels = map[DebugLevel]string{
 	ERROR:   "ERROR",
 }
 
-var debugLevel DebugLevel = ERROR
-var debugLog bool = true
+var debugLevel = ERROR
+var debugLog = true
 
 // OboeLog print logs based on the debug level.
 func OboeLog(level DebugLevel, msg string, args ...interface{}) {

--- a/v1/ao/layer.go
+++ b/v1/ao/layer.go
@@ -174,9 +174,15 @@ func (s *layerSpan) SetAsync(val bool) {
 
 // SetTransactionName sets the transaction name used to categorize service requests in AppOptics.
 func (s *span) SetTransactionName(name string) {
-	if name != "" {
-		s.aoCtx.SetTransactionName(name)
+	if !s.ok() {
+		reporter.OboeLog(reporter.DEBUG, "failed to set custom transaction name, invalid span")
+		return
 	}
+	if name == "" || len(name) > 255 {
+		reporter.OboeLog(reporter.DEBUG, "valid length for custom transaction name: 1~255")
+		return
+	}
+	s.aoCtx.SetTransactionName(name)
 }
 
 // Error reports an error, distinguished by its class and message

--- a/v1/ao/layer.go
+++ b/v1/ao/layer.go
@@ -44,6 +44,10 @@ type Span interface {
 	// concurrent overlapping child Spans.
 	SetAsync(bool)
 
+	// SetTransactionName sets this service's transaction name.
+	// It is used for categorizing service metrics and traces in AppOptics.
+	SetTransactionName(string)
+
 	IsReporting() bool
 	addChildEdge(reporter.Context)
 	addProfile(Profile)
@@ -161,10 +165,17 @@ func (s *layerSpan) IsSampled() bool {
 	return false
 }
 
-// SetAsync(true) provides a hint that this Span is a parent of concurrent overlapping child Spans.
+// SetAsync provides a hint that this Span is a parent of concurrent overlapping child Spans.
 func (s *layerSpan) SetAsync(val bool) {
 	if val {
 		s.AddEndArgs("Async", true)
+	}
+}
+
+// SetTransactionName sets the transaction name used to categorize service requests in AppOptics.
+func (s *span) SetTransactionName(name string) {
+	if name != "" {
+		s.aoCtx.SetTransactionName(name)
 	}
 }
 
@@ -215,6 +226,7 @@ func (s nullSpan) aoContext() reporter.Context                           { retur
 func (s nullSpan) MetadataString() string                                { return "" }
 func (s nullSpan) IsSampled() bool                                       { return false }
 func (s nullSpan) SetAsync(bool)                                         {}
+func (s nullSpan) SetTransactionName(string)                             {}
 
 // is this span still valid (has it timed out, expired, not sampled)
 func (s *span) ok() bool {

--- a/v1/ao/layer.go
+++ b/v1/ao/layer.go
@@ -54,6 +54,9 @@ type Span interface {
 	// It is used for categorizing service metrics and traces in AppOptics.
 	SetTransactionName(string) error
 
+	// GetTransactionName returns the current value of the transaction name
+	GetTransactionName() string
+
 	IsReporting() bool
 	addChildEdge(reporter.Context)
 	addProfile(Profile)
@@ -190,6 +193,11 @@ func (s *span) SetTransactionName(name string) error {
 	return nil
 }
 
+// GetTransactionName returns the current value of the transaction name
+func (s *span) GetTransactionName() string {
+	return s.aoCtx.GetTransactionName()
+}
+
 // Error reports an error, distinguished by its class and message
 func (s *span) Error(class, msg string) {
 	if s.ok() {
@@ -238,6 +246,7 @@ func (s nullSpan) MetadataString() string                                { retur
 func (s nullSpan) IsSampled() bool                                       { return false }
 func (s nullSpan) SetAsync(bool)                                         {}
 func (s nullSpan) SetTransactionName(string) error                       { return nil }
+func (s nullSpan) GetTransactionName() string                            { return "" }
 
 // is this span still valid (has it timed out, expired, not sampled)
 func (s *span) ok() bool {

--- a/v1/ao/layer.go
+++ b/v1/ao/layer.go
@@ -182,7 +182,7 @@ func (s *span) SetTransactionName(name string) {
 // Error reports an error, distinguished by its class and message
 func (s *span) Error(class, msg string) {
 	if s.ok() {
-		_ = s.aoCtx.ReportEvent(reporter.LabelError, s.layerName(),
+		s.aoCtx.ReportEvent(reporter.LabelError, s.layerName(),
 			"ErrorClass", class, "ErrorMsg", msg, "Backtrace", debug.Stack())
 	}
 }
@@ -190,7 +190,7 @@ func (s *span) Error(class, msg string) {
 // Err reports the provided error type
 func (s *span) Err(err error) {
 	if s.ok() && err != nil {
-		_ = s.aoCtx.ReportEvent(reporter.LabelError, s.layerName(),
+		s.aoCtx.ReportEvent(reporter.LabelError, s.layerName(),
 			"ErrorClass", "error", "ErrorMsg", err.Error(), "Backtrace", debug.Stack())
 	}
 }
@@ -230,9 +230,12 @@ func (s nullSpan) SetTransactionName(string)                             {}
 
 // is this span still valid (has it timed out, expired, not sampled)
 func (s *span) ok() bool {
+	if s == nil {
+		return false
+	}
 	s.lock.RLock()
 	defer s.lock.RUnlock()
-	return s != nil && !s.ended
+	return !s.ended
 }
 func (s *span) IsReporting() bool           { return s.ok() }
 func (s *span) aoContext() reporter.Context { return s.aoCtx }

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -35,17 +35,16 @@ type Trace interface {
 	// method to set a response header in advance of calling End().
 	ExitMetadata() string
 
-	// SetStartTime sets the start time of a trace.
-	SetStartTime(start time.Time)
-
-	// SetMethod sets the request's HTTP method of the trace, if any
+	// SetMethod sets the request's HTTP method of the trace, if any.
+	// It is used for categorizing service metrics and traces in AppOptics.
 	SetMethod(method string)
 
-	// SetStatus sets the request's HTTP status code of the trace, if any
+	// SetStatus sets the request's HTTP status code of the trace, if any.
+	// It is used for categorizing service metrics and traces in AppOptics.
 	SetStatus(status int)
 
-	// SetControllerAction sets controller/action for the trace
-	SetControllerAction(controller, action string)
+	// SetStartTime sets the start time of a span.
+	SetStartTime(start time.Time)
 }
 
 // KVMap is a map of additional key-value pairs to report along with the event data provided
@@ -139,12 +138,6 @@ func (t *aoTrace) SetStatus(status int) {
 	t.httpSpan.span.Status = status
 }
 
-// SetControllerAction sets the controller and action
-func (t *aoTrace) SetControllerAction(controller, action string) {
-	t.httpSpan.controller = controller
-	t.httpSpan.action = action
-}
-
 func (t *aoTrace) reportExit() {
 	if t.ok() {
 		t.lock.Lock()
@@ -230,13 +223,12 @@ func (t *aoTrace) recordHTTPSpan() {
 // A nullTrace is not tracing.
 type nullTrace struct{ nullSpan }
 
-func (t *nullTrace) EndCallback(f func() KVMap)                    {}
-func (t *nullTrace) ExitMetadata() string                          { return "" }
-func (t *nullTrace) SetStartTime(start time.Time)                  {}
-func (t *nullTrace) SetMethod(method string)                       {}
-func (t *nullTrace) SetStatus(status int)                          {}
-func (t *nullTrace) SetControllerAction(controller, action string) {}
-func (t *nullTrace) recordMetrics()                                {}
+func (t *nullTrace) EndCallback(f func() KVMap)   {}
+func (t *nullTrace) ExitMetadata() string         { return "" }
+func (t *nullTrace) SetStartTime(start time.Time) {}
+func (t *nullTrace) SetMethod(method string)      {}
+func (t *nullTrace) SetStatus(status int)         {}
+func (t *nullTrace) recordMetrics()               {}
 
 // NewNullTrace returns a trace that is not sampled.
 func NewNullTrace() Trace { return &nullTrace{} }

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -56,7 +56,7 @@ type Trace interface {
 type KVMap map[string]interface{}
 
 type traceHTTPSpan struct {
-	span       reporter.HttpSpanMessage
+	span       reporter.HTTPSpanMessage
 	start      time.Time
 	controller string
 	action     string

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 // Trace represents a distributed trace for this request that reports
@@ -109,6 +111,26 @@ func NewTraceFromID(spanName, mdstr string, cb func() KVMap) Trace {
 	}
 	t.SetStartTime(time.Now())
 	return t
+}
+
+// SetTransactionName can be called inside a http handler to set the custom transaction name.
+func SetTransactionName(ctx context.Context, name string) error {
+	var t Trace
+	if t = TraceFromContext(ctx); t == nil {
+		return errors.New("no trace metadata found in your context")
+	}
+
+	return t.SetTransactionName(name)
+}
+
+// GetTransactionName fetches the current transaction name from the context
+func GetTransactionName(ctx context.Context) (string, error) {
+	var t Trace
+	if t = TraceFromContext(ctx); t == nil {
+		return "", errors.New("no trace metadata found in your context")
+	}
+
+	return t.GetTransactionName(), nil
 }
 
 // End reports the exit event for the span name that was used when calling NewTrace().

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
-	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -115,22 +114,12 @@ func NewTraceFromID(spanName, mdstr string, cb func() KVMap) Trace {
 
 // SetTransactionName can be called inside a http handler to set the custom transaction name.
 func SetTransactionName(ctx context.Context, name string) error {
-	var t Trace
-	if t = TraceFromContext(ctx); t == nil {
-		return errors.New("no trace metadata found in your context")
-	}
-
-	return t.SetTransactionName(name)
+	return TraceFromContext(ctx).SetTransactionName(name)
 }
 
 // GetTransactionName fetches the current transaction name from the context
-func GetTransactionName(ctx context.Context) (string, error) {
-	var t Trace
-	if t = TraceFromContext(ctx); t == nil {
-		return "", errors.New("no trace metadata found in your context")
-	}
-
-	return t.GetTransactionName(), nil
+func GetTransactionName(ctx context.Context) string {
+	return TraceFromContext(ctx).GetTransactionName()
 }
 
 // End reports the exit event for the span name that was used when calling NewTrace().

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -207,7 +207,12 @@ func (t *aoTrace) recordHTTPSpan() {
 		}
 	}
 
-	if t.httpSpan.controller != "" && t.httpSpan.action != "" {
+	// The precedence:
+	// custom transaction name > framework specific transaction naming > controller.action > 1st and 2nd segment of URL
+	customTxnName := t.aoCtx.GetTransactionName()
+	if customTxnName != "" {
+		t.httpSpan.span.Transaction = customTxnName
+	} else if t.httpSpan.controller != "" && t.httpSpan.action != "" {
 		t.httpSpan.span.Transaction = t.httpSpan.controller + "." + t.httpSpan.action
 	} else if controller != "" && action != "" {
 		t.httpSpan.span.Transaction = controller + "." + action

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -207,6 +207,7 @@ func (t *aoTrace) recordHTTPSpan() {
 		}
 	}
 
+	t.httpSpan.span.Transaction = reporter.UnknownTransactionName
 	// The precedence:
 	// custom transaction name > framework specific transaction naming > controller.action > 1st and 2nd segment of URL
 	customTxnName := t.aoCtx.GetTransactionName()
@@ -216,6 +217,8 @@ func (t *aoTrace) recordHTTPSpan() {
 		t.httpSpan.span.Transaction = t.httpSpan.controller + "." + t.httpSpan.action
 	} else if controller != "" && action != "" {
 		t.httpSpan.span.Transaction = controller + "." + action
+	} else if t.httpSpan.span.URL != "" {
+		t.httpSpan.span.Transaction = reporter.GetTransactionFromURL(t.httpSpan.span.URL)
 	}
 
 	if t.httpSpan.span.Status >= 500 && t.httpSpan.span.Status < 600 {

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -153,9 +153,9 @@ func (t *aoTrace) reportExit() {
 			t.endArgs = append(t.endArgs, "Edge", edge)
 		}
 		if t.exitEvent != nil { // use exit event, if one was provided
-			_ = t.exitEvent.ReportContext(t.aoCtx, true, t.endArgs...)
+			t.exitEvent.ReportContext(t.aoCtx, true, t.endArgs...)
 		} else {
-			_ = t.aoCtx.ReportEvent(reporter.LabelExit, t.layerName(), t.endArgs...)
+			t.aoCtx.ReportEvent(reporter.LabelExit, t.layerName(), t.endArgs...)
 		}
 
 		t.childEdges = nil // clear child edge list
@@ -223,6 +223,9 @@ func (t *aoTrace) recordHTTPSpan() {
 	}
 
 	reporter.ReportSpan(&t.httpSpan.span)
+
+	// This will report TransactionName KV in the exit event.
+	t.endArgs = append(t.endArgs, "TransactionName", t.httpSpan.span.Transaction)
 }
 
 // A nullTrace is not tracing.


### PR DESCRIPTION
Jira link: https://swicloud.atlassian.net/browse/AO-7051
1. Added API for setting custom transaction names
2. Added the environment variable APPOPTICS_PREPEND_DOMAIN to control if the domain should be added to the transaction names
3. Streamlined the logic of getting transaction names
4. Other minor changes

PR for doc update: https://github.com/librato/ao-kb-docs/pull/463