### PR TITLE
AO-8587: Use X-Forwarded-Host as the domain if available

### DIFF
--- a/v1/ao/http_instrumentation.go
+++ b/v1/ao/http_instrumentation.go
@@ -144,7 +144,13 @@ func traceFromHTTPRequest(spanName string, r *http.Request, isNewcontext bool) T
 	// set the start time and method for metrics collection
 	t.SetMethod(r.Method)
 	t.SetPath(r.URL.EscapedPath())
-	t.SetHost(r.Host)
+
+	var host string
+	if host = r.Header.Get("X-Forwarded-Host"); host == "" {
+		host = r.Host
+	}
+	t.SetHost(host)
+
 	// Clear the start time if it is not a new context
 	if !isNewcontext {
 		t.SetStartTime(time.Time{})

--- a/v1/ao/http_instrumentation_oboe_test.go
+++ b/v1/ao/http_instrumentation_oboe_test.go
@@ -17,6 +17,8 @@ func TestCustomTransactionNameWithDomain(t *testing.T) {
 	os.Setenv("APPOPTICS_PREPEND_DOMAIN", "true")
 
 	r := reporter.SetTestReporter() // set up test reporter
+
+	// Test prepending the domain to transaction names.
 	httpTestWithEndpoint(handler200, "http://test.com/hello world/one/two/three?testq")
 	r.Close(2)
 	g.AssertGraph(t, r.EventBufs, 2, g.AssertNodeMap{
@@ -27,6 +29,25 @@ func TestCustomTransactionNameWithDomain(t *testing.T) {
 		{"http.HandlerFunc", "exit"}: {Edges: g.Edges{{"http.HandlerFunc", "entry"}}, Callback: func(n g.Node) {
 			// assert that response X-Trace header matches trace exit event
 			assert.True(t, strings.HasPrefix(n.Map["TransactionName"].(string), "test.com/final-my-custom-transaction-name"))
+		}},
+	})
+
+	r = reporter.SetTestReporter() // set up test reporter
+
+	// Test using X-Forwarded-Host if available.
+	hd := map[string]string{
+		"X-Forwarded-Host": "test2.com",
+	}
+	httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello world/one/two/three?testq", hd)
+	r.Close(2)
+	g.AssertGraph(t, r.EventBufs, 2, g.AssertNodeMap{
+		// entry event should have no edges
+		{"http.HandlerFunc", "entry"}: {Edges: g.Edges{}, Callback: func(n g.Node) {
+			assert.Equal(t, "test.com", n.Map["HTTP-Host"])
+		}},
+		{"http.HandlerFunc", "exit"}: {Edges: g.Edges{{"http.HandlerFunc", "entry"}}, Callback: func(n g.Node) {
+			// assert that response X-Trace header matches trace exit event
+			assert.True(t, strings.HasPrefix(n.Map["TransactionName"].(string), "test2.com/final-my-custom-transaction-name"))
 		}},
 	})
 	os.Unsetenv("APPOPTICS_PREPEND_DOMAIN")

--- a/v1/ao/http_instrumentation_test.go
+++ b/v1/ao/http_instrumentation_test.go
@@ -65,9 +65,16 @@ func handlerDoubleWrapped(w http.ResponseWriter, r *http.Request) {
 }
 
 func httpTestWithEndpoint(f http.HandlerFunc, ep string) *httptest.ResponseRecorder {
+	return httpTestWithEndpointWithHeaders(f, ep, nil)
+}
+
+func httpTestWithEndpointWithHeaders(f http.HandlerFunc, ep string, hd map[string]string) *httptest.ResponseRecorder {
 	h := http.HandlerFunc(ao.HTTPHandler(f))
 	// test a single GET request
 	req, _ := http.NewRequest("GET", ep, nil)
+	for k, v := range hd {
+		req.Header.Set(k, v)
+	}
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 	return w


### PR DESCRIPTION
From the spec:
Per the web request KV spec, the HTTP-Host KV is required and contains domain information, this should be used as the domain value. There is also an optional Forwarded-Host KV that if available should be used in preference over HTTP-Host.

