### PR TITLE
AO-8448 log overridden

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,18 +22,22 @@ install:
 
 script:
   - cd $GOPATH/src/github.com/appoptics/appoptics-apm-go/v1/ao
-  - go build -v github.com/appoptics/appoptics-apm-go/v1/ao github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter
-  - go test -v -covermode=atomic -coverprofile=cov.out -coverpkg github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao
-  - go test -v -tags disable_tracing -covermode=atomic -coverprofile=covao.out -coverpkg github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao
+  - go build -v github.com/appoptics/appoptics-apm-go/v1/ao github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent
+  - go test -v -covermode=atomic -coverprofile=cov.out -coverpkg github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent,github.com/appoptics/appoptics-apm-go/v1/ao
+  - go test -v -tags disable_tracing -covermode=atomic -coverprofile=covao.out -coverpkg github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent,github.com/appoptics/appoptics-apm-go/v1/ao
   - pushd internal/reporter/
   - go test -v -covermode=atomic -coverprofile=cov.out
   - go test -v -tags disable_tracing -covermode=atomic -coverprofile=covao.out
   - popd
-  - pushd opentracing
-  - go test -v -covermode=atomic -coverprofile=cov.out -coverpkg github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao/opentracing,github.com/appoptics/appoptics-apm-go/v1/ao
-  - go test -v -tags disable_tracing -covermode=atomic -coverprofile=covao.out -coverpkg github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao/opentracing,github.com/appoptics/appoptics-apm-go/v1/ao
+  - pushd internal/agent/
+  - go test -v -covermode=atomic -coverprofile=cov.out
+  - go test -v -tags disable_tracing -covermode=atomic -coverprofile=covao.out
   - popd
-  - gocovmerge cov.out covao.out internal/reporter/cov.out internal/reporter/covao.out opentracing/cov.out opentracing/covao.out > coverage.txt
+  - pushd opentracing
+  - go test -v -covermode=atomic -coverprofile=cov.out -coverpkg github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent,github.com/appoptics/appoptics-apm-go/v1/ao/opentracing,github.com/appoptics/appoptics-apm-go/v1/ao
+  - go test -v -tags disable_tracing -covermode=atomic -coverprofile=covao.out -coverpkg github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent,github.com/appoptics/appoptics-apm-go/v1/ao/opentracing,github.com/appoptics/appoptics-apm-go/v1/ao
+  - popd
+  - gocovmerge cov.out covao.out internal/reporter/cov.out internal/reporter/covao.out internal/agent/cov.out internal/agent/covao.out opentracing/cov.out opentracing/covao.out > coverage.txt
 
 after_success:
   - if [[ $TRAVIS_GO_VERSION == 1.9* ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ env:
   global:
     - GO15VENDOREXPERIMENT=1
     - APPOPTICS_DEBUG_LEVEL=1
-    - APPOPTICS_SERVICE_KEY=123abc:Go
-        
+
 install:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ These environment variables may be set:
 | Variable Name        | Required           | Default  | Description |
 | -------------------- | ------------------ | -------- | ----------- |
 |APPOPTICS_SERVICE_KEY|Yes||The service key identifies the service being instrumented within your Organization. It should be in the form of ``<api token>:<service name>``.|
-|APPOPTICS_DEBUG_LEVEL|No|ERROR|Logging level to adjust the logging verbosity. Increase the logging verbosity to one of the debug levels to get more detailed information. Possible values: DEBUG, INFO, WARN, ERROR|
+|APPOPTICS_DEBUG_LEVEL|No|WARN|Logging level to adjust the logging verbosity. Increase the logging verbosity to one of the debug levels to get more detailed information. Possible values: DEBUG, INFO, WARN, ERROR|
 |APPOPTICS_HOSTNAME_ALIAS|No||A logical/readable hostname that can be used to easily identify the host|
 |APPOPTICS_TRACING_MODE|No|always|Mode "always" will instruct AppOptics to consider sampling every inbound request for tracing. Mode "never" will disable tracing, and will neither start nor continue traces.|
 |APPOPTICS_REPORTER|No|ssl|The reporter that will be used throughout the runtime of the app. Possible values: ssl, udp, none|

--- a/v1/ao/cov.sh
+++ b/v1/ao/cov.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 set -e
 
-COVERPKG="github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao,github.com/appoptics/appoptics-apm-go/v1/ao/opentracing"
-export APPOPTICS_DEBUG_LEVEL=0
+COVERPKG="github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent,github.com/appoptics/appoptics-apm-go/v1/ao,github.com/appoptics/appoptics-apm-go/v1/ao/opentracing"
+export APPOPTICS_DEBUG_LEVEL=1
 go test -v -covermode=count -coverprofile=cov.out -coverpkg $COVERPKG
 go test -v -tags disable_tracing -covermode=count -coverprofile=covao.out -coverpkg $COVERPKG
 
 pushd internal/reporter/
+go test -v -covermode=count -coverprofile=cov.out
+go test -v -tags disable_tracing -covermode=count -coverprofile=covao.out
+popd
+
+pushd internal/agent/
 go test -v -covermode=count -coverprofile=cov.out
 go test -v -tags disable_tracing -covermode=count -coverprofile=covao.out
 popd
@@ -16,6 +21,6 @@ go test -v -covermode=count -coverprofile=cov.out
 go test -v -tags disable_tracing -covermode=count -coverprofile=covao.out
 popd
 
-gocovmerge cov.out covao.out internal/reporter/cov.out internal/reporter/covao.out opentracing/cov.out opentracing/covao.out > covmerge.out
+gocovmerge cov.out covao.out internal/reporter/cov.out internal/reporter/covao.out internal/agent/cov.out internal/agent/covao.out opentracing/cov.out opentracing/covao.out > covmerge.out
 
 #go tool cover -html=covmerge.out

--- a/v1/ao/http_instrumentation_oboe_test.go
+++ b/v1/ao/http_instrumentation_oboe_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent"
 	g "github.com/appoptics/appoptics-apm-go/v1/ao/internal/graphtest"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
 	"github.com/stretchr/testify/assert"
@@ -15,7 +16,7 @@ import (
 
 func TestCustomTransactionNameWithDomain(t *testing.T) {
 	os.Setenv("APPOPTICS_PREPEND_DOMAIN", "true")
-
+	agent.Init()
 	r := reporter.SetTestReporter() // set up test reporter
 
 	// Test prepending the domain to transaction names.

--- a/v1/ao/http_instrumentation_test.go
+++ b/v1/ao/http_instrumentation_test.go
@@ -16,7 +16,10 @@ import (
 	"testing"
 	"time"
 
+	"os"
+
 	"github.com/appoptics/appoptics-apm-go/v1/ao"
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent"
 	g "github.com/appoptics/appoptics-apm-go/v1/ao/internal/graphtest"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
 	"github.com/stretchr/testify/assert"
@@ -110,6 +113,8 @@ func TestHTTPHandler404(t *testing.T) {
 }
 
 func TestHTTPHandler200(t *testing.T) {
+	os.Setenv("APPOPTICS_PREPEND_DOMAIN", "false")
+	agent.Init()
 	r := reporter.SetTestReporter() // set up test reporter
 	response := httpTestWithEndpoint(handler200, "http://test.com/hello world/one/two/three?testq")
 

--- a/v1/ao/internal/agent/agent.go
+++ b/v1/ao/internal/agent/agent.go
@@ -1,0 +1,18 @@
+// Package agent is the place to manage all the agent properties, which include:
+// 1. static configurations (loaded from system environment variables and (in future) configuration files, etc.
+// 2. dynamic settings pushed down by the AppOptics server.
+// The static configurations are (supposed to be) read only after initialization, so it's goroutine safe
+// The dynamic settings need to be protected by mutexes
+package agent
+
+// Initialize the agent
+func init() {
+	Init()
+}
+
+// Init initializes the agent.
+// Make it visible to outside world only for the sake of testing. Don't call it manually anywhere else
+func Init() {
+	initConf(&agentConf)
+	initLogging()
+}

--- a/v1/ao/internal/agent/agent.go
+++ b/v1/ao/internal/agent/agent.go
@@ -15,6 +15,6 @@ func init() {
 // Init initializes the agent.
 // Make it visible to outside world only for the sake of testing. Don't call it manually anywhere else
 func Init() {
-	initConf(&agentConf)
+	initConf(agentConf)
 	initLogging()
 }

--- a/v1/ao/internal/agent/agent.go
+++ b/v1/ao/internal/agent/agent.go
@@ -13,7 +13,9 @@ func init() {
 }
 
 // Init initializes the agent.
-// Make it visible to outside world only for the sake of testing. Don't call it manually anywhere else
+// Make it visible to outside world only for the sake of testing. Don't call it manually anywhere else.
+// ATTENTION: You need to call this function manually after changing the environment variables in your
+// test cases, as normally the configuration only initializes once when the program starts up.
 func Init() {
 	initConf(agentConf)
 	initLogging()

--- a/v1/ao/internal/agent/agent.go
+++ b/v1/ao/internal/agent/agent.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2017 Librato, Inc. All rights reserved.
+
 // Package agent is the place to manage all the agent properties, which include:
 // 1. static configurations (loaded from system environment variables and (in future) configuration files, etc.
 // 2. dynamic settings pushed down by the AppOptics server.

--- a/v1/ao/internal/agent/config.go
+++ b/v1/ao/internal/agent/config.go
@@ -1,0 +1,34 @@
+// This package is used to initialize and fetch the static conf options
+// which will not be changed once initialized.
+// So mutexes/locks are not required to access the values
+package agent
+
+type ConfName string
+
+// All the configuration items currently supported
+const (
+	AppOpticsCollector          = ConfName("APPOPTICS_COLLECTOR")
+	AppOpticsServiceKey         = ConfName("APPOPTICS_SERVICE_KEY")
+	AppOpticsDebugLevel         = ConfName("APPOPTICS_DEBUG_LEVEL")
+	AppOpticsTrustedPath        = ConfName("APPOPTICS_TRUSTEDPATH")
+	AppOpticsCollectorUDP       = ConfName("APPOPTICS_COLLECTOR_UDP")
+	AppOpticsReporter           = ConfName("APPOPTICS_REPORTER")
+	AppOpticsTracingMode        = ConfName("APPOPTICS_TRACING_MODE")
+	AppOpticsPrependDomain      = ConfName("APPOPTICS_PREPEND_DOMAIN")
+	AppOpticsHostnameAlias      = ConfName("APPOPTICS_HOSTNAME_ALIAS")
+	AppOpticsInsecureSkipVerify = ConfName("APPOPTICS_INSECURE_SKIP_VERIFY")
+	AppOpticsHistogramPrecision = ConfName("APPOPTICS_HISTOGRAM_PRECISION")
+)
+
+// GetConfig returns the value of a configuration item. Empty string will be returned
+// if the item is unset or non-exist and the returned value is ensured lowercase
+func GetConfig(n ConfName) string {
+	if !agentConf.initialized {
+		return ""
+	}
+	v, ok := agentConf.items[n]
+	if !ok {
+		return ""
+	}
+	return v
+}

--- a/v1/ao/internal/agent/config.go
+++ b/v1/ao/internal/agent/config.go
@@ -1,6 +1,5 @@
-// This package is used to initialize and fetch the static conf options
-// which will not be changed once initialized.
-// So mutexes/locks are not required to access the values
+// Copyright (C) 2017 Librato, Inc. All rights reserved.
+
 package agent
 
 type ConfName string
@@ -9,7 +8,7 @@ type ConfName string
 const (
 	AppOpticsCollector          = ConfName("APPOPTICS_COLLECTOR")
 	AppOpticsServiceKey         = ConfName("APPOPTICS_SERVICE_KEY")
-	AppOpticsDebugLevel         = ConfName("APPOPTICS_DEBUG_LEVEL")
+	AppOpticsLogLevel           = ConfName("APPOPTICS_DEBUG_LEVEL")
 	AppOpticsTrustedPath        = ConfName("APPOPTICS_TRUSTEDPATH")
 	AppOpticsCollectorUDP       = ConfName("APPOPTICS_COLLECTOR_UDP")
 	AppOpticsReporter           = ConfName("APPOPTICS_REPORTER")

--- a/v1/ao/internal/agent/config_builder.go
+++ b/v1/ao/internal/agent/config_builder.go
@@ -1,0 +1,84 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+
+	"strings"
+)
+
+type configBuilder struct {
+	name         ConfName
+	defaultValue string
+	builders     []initFunc
+	// TODO: validator func
+}
+
+type conf struct {
+	initialized bool
+	items       map[ConfName]string
+}
+
+type initFunc func(n ConfName) string
+
+// Environment variable reader. Empty string is considered as invalid so just use os.Getenv()
+// to ignore empty environment variables
+var envVar initFunc = func(n ConfName) string {
+	return strings.ToLower(os.Getenv(string(n)))
+}
+
+// Default values
+const (
+	defaultSSLCollector       = "collector.appoptics.com:443"
+	defaultServiceKey         = ""
+	defaultDebugLevel         = "WARN"
+	defaultTrustedPath        = ""
+	defaultCollectorUDP       = "127.0.0.1:7831"
+	defaultReporter           = "ssl"
+	defaultTracingMode        = "always"
+	defaultPrependDomain      = "false"
+	defaultHostnameAlias      = ""
+	defaultInsecureSkipVerify = "false"
+	defaultHistogramPrecision = ""
+)
+
+var cb = []configBuilder{
+	{AppOpticsCollector, defaultSSLCollector, []initFunc{envVar}},
+	{AppOpticsServiceKey, defaultServiceKey, []initFunc{envVar}},
+	{AppOpticsDebugLevel, defaultDebugLevel, []initFunc{envVar}},
+	{AppOpticsTrustedPath, defaultTrustedPath, []initFunc{envVar}},
+	{AppOpticsCollectorUDP, defaultCollectorUDP, []initFunc{envVar}},
+	{AppOpticsReporter, defaultReporter, []initFunc{envVar}},
+	{AppOpticsTracingMode, defaultTracingMode, []initFunc{envVar}},
+	{AppOpticsPrependDomain, defaultPrependDomain, []initFunc{envVar}},
+	{AppOpticsHostnameAlias, defaultHostnameAlias, []initFunc{envVar}},
+	{AppOpticsInsecureSkipVerify, defaultInsecureSkipVerify, []initFunc{envVar}},
+	{AppOpticsHistogramPrecision, defaultHistogramPrecision, []initFunc{envVar}},
+}
+
+// The package variable to store all configurations, which is read only after initialized.
+var agentConf = conf{
+	initialized: false,
+	items:       make(map[ConfName]string),
+}
+
+func initConf(cf *conf) {
+	Log(INFO, "initializing the AppOptics agent")
+	for _, item := range cb {
+		k := item.name
+		v := ""
+		l := len(item.builders) - 1
+		for i := l; i >= 0; i-- {
+			v = item.builders[i](k)
+			if v != "" {
+				Log(WARNING, fmt.Sprintf("non-default configuration used %v=%v", k, v))
+				break
+			}
+		}
+		if v == "" {
+			v = item.defaultValue
+		}
+		cf.items[k] = v
+	}
+	cf.initialized = true
+}

--- a/v1/ao/internal/agent/config_builder.go
+++ b/v1/ao/internal/agent/config_builder.go
@@ -4,7 +4,6 @@ package agent
 
 import (
 	"os"
-
 	"strings"
 	"unicode/utf8"
 )
@@ -13,7 +12,7 @@ type configBuilder struct {
 	name         ConfName
 	defaultValue string
 	builders     []initFunc
-	// TODO: validator func
+	// TODO: validation func
 }
 
 type conf struct {

--- a/v1/ao/internal/agent/config_builder.go
+++ b/v1/ao/internal/agent/config_builder.go
@@ -89,8 +89,9 @@ func initConf(cf *conf) {
 	cf.initialized = true
 }
 
-// verifyAndMaskServiceKey verifies if the service key is valid. If so, it then masks the
-// middle part of the token and returns the masked service key
+// maskServiceKey masks the middle part of the token and returns the masked service key
+// For example, the key "ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189217:go"
+// will be masked to "ae38********************************************************9217:go"
 func maskServiceKey(validKey string) string {
 	var sep = ":"
 	var hLen, tLen = 4, 4

--- a/v1/ao/internal/agent/config_builder.go
+++ b/v1/ao/internal/agent/config_builder.go
@@ -58,13 +58,13 @@ var cb = []configBuilder{
 }
 
 // The package variable to store all configurations, which is read only after initialized.
-var agentConf = conf{
+var agentConf = &conf{
 	initialized: false,
 	items:       make(map[ConfName]string),
 }
 
 func initConf(cf *conf) {
-	Log(INFO, "initializing the AppOptics agent")
+	Info("initializing the AppOptics agent")
 	for _, item := range cb {
 		k := item.name
 		v := ""
@@ -76,7 +76,7 @@ func initConf(cf *conf) {
 				if k == "APPOPTICS_SERVICE_KEY" {
 					val = maskServiceKey(val)
 				}
-				Warning("non-default configuration used %v=%v", k, val)
+				Warningf("non-default configuration used %v=%v", k, val)
 
 				break
 			}

--- a/v1/ao/internal/agent/config_builder.go
+++ b/v1/ao/internal/agent/config_builder.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2017 Librato, Inc. All rights reserved.
+
 package agent
 
 import (
@@ -31,7 +33,7 @@ var envVar initFunc = func(n ConfName) string {
 const (
 	defaultSSLCollector       = "collector.appoptics.com:443"
 	defaultServiceKey         = ""
-	defaultDebugLevel         = "WARN"
+	defaultLogLevel           = "WARN"
 	defaultTrustedPath        = ""
 	defaultCollectorUDP       = "127.0.0.1:7831"
 	defaultReporter           = "ssl"
@@ -45,7 +47,7 @@ const (
 var cb = []configBuilder{
 	{AppOpticsCollector, defaultSSLCollector, []initFunc{envVar}},
 	{AppOpticsServiceKey, defaultServiceKey, []initFunc{envVar}},
-	{AppOpticsDebugLevel, defaultDebugLevel, []initFunc{envVar}},
+	{AppOpticsLogLevel, defaultLogLevel, []initFunc{envVar}},
 	{AppOpticsTrustedPath, defaultTrustedPath, []initFunc{envVar}},
 	{AppOpticsCollectorUDP, defaultCollectorUDP, []initFunc{envVar}},
 	{AppOpticsReporter, defaultReporter, []initFunc{envVar}},

--- a/v1/ao/internal/agent/config_builder.go
+++ b/v1/ao/internal/agent/config_builder.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"fmt"
 	"os"
 
 	"strings"
@@ -76,7 +75,7 @@ func initConf(cf *conf) {
 				if k == "APPOPTICS_SERVICE_KEY" {
 					val = maskServiceKey(val)
 				}
-				Log(WARNING, fmt.Sprintf("non-default configuration used %v=%v", k, val))
+				Warning("non-default configuration used %v=%v", k, val)
 
 				break
 			}

--- a/v1/ao/internal/agent/config_builder_test.go
+++ b/v1/ao/internal/agent/config_builder_test.go
@@ -18,6 +18,7 @@ func TestInitConf(t *testing.T) {
 	r := os.Getenv("APPOPTICS_REPORTER")
 	os.Unsetenv("APPOPTICS_REPORTER")
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "debug")
+	os.Setenv("APPOPTICS_SERVICE_KEY", "1234567890abcdef:go")
 	log.SetOutput(&buffer)
 	Init()
 	assert.True(t, strings.HasSuffix(buffer.String(), "non-default configuration used APPOPTICS_DEBUG_LEVEL=debug\n"))

--- a/v1/ao/internal/agent/config_builder_test.go
+++ b/v1/ao/internal/agent/config_builder_test.go
@@ -6,9 +6,8 @@ import (
 	"bytes"
 	"log"
 	"os"
-	"testing"
-
 	"strings"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/v1/ao/internal/agent/config_builder_test.go
+++ b/v1/ao/internal/agent/config_builder_test.go
@@ -1,0 +1,21 @@
+package agent
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"testing"
+
+	"strings"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitConf(t *testing.T) {
+	var buffer bytes.Buffer
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "debug")
+	log.SetOutput(&buffer)
+	Init()
+	assert.True(t, strings.HasSuffix(buffer.String(), "non-default configuration used APPOPTICS_DEBUG_LEVEL=debug\n"))
+}

--- a/v1/ao/internal/agent/config_builder_test.go
+++ b/v1/ao/internal/agent/config_builder_test.go
@@ -19,3 +19,15 @@ func TestInitConf(t *testing.T) {
 	Init()
 	assert.True(t, strings.HasSuffix(buffer.String(), "non-default configuration used APPOPTICS_DEBUG_LEVEL=debug\n"))
 }
+
+func TestMaskServiceKey(t *testing.T) {
+	keyPairs := map[string]string{
+		"1234567890abcdef:Go": "1234********cdef:Go",
+		"abc:Go":              "abc:Go",
+		"abcd1234:Go":         "abcd1234:Go",
+	}
+
+	for key, masked := range keyPairs {
+		assert.Equal(t, masked, maskServiceKey(key))
+	}
+}

--- a/v1/ao/internal/agent/config_builder_test.go
+++ b/v1/ao/internal/agent/config_builder_test.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2017 Librato, Inc. All rights reserved.
+
 package agent
 
 import (

--- a/v1/ao/internal/agent/config_builder_test.go
+++ b/v1/ao/internal/agent/config_builder_test.go
@@ -14,10 +14,14 @@ import (
 func TestInitConf(t *testing.T) {
 	var buffer bytes.Buffer
 
+	r := os.Getenv("APPOPTICS_REPORTER")
+	os.Unsetenv("APPOPTICS_REPORTER")
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "debug")
 	log.SetOutput(&buffer)
 	Init()
 	assert.True(t, strings.HasSuffix(buffer.String(), "non-default configuration used APPOPTICS_DEBUG_LEVEL=debug\n"))
+
+	os.Setenv("APPOPTICS_REPORTER", r)
 }
 
 func TestMaskServiceKey(t *testing.T) {

--- a/v1/ao/internal/agent/config_test.go
+++ b/v1/ao/internal/agent/config_test.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2017 Librato, Inc. All rights reserved.
+
 package agent
 
 import (

--- a/v1/ao/internal/agent/config_test.go
+++ b/v1/ao/internal/agent/config_test.go
@@ -3,9 +3,8 @@
 package agent
 
 import (
-	"testing"
-
 	"os"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/v1/ao/internal/agent/config_test.go
+++ b/v1/ao/internal/agent/config_test.go
@@ -1,0 +1,27 @@
+package agent
+
+import (
+	"testing"
+
+	"os"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetConfig(t *testing.T) {
+	agentConf.initialized = false
+	assert.Equal(t, "", GetConfig(ConfName("APPOPTICS_COLLECTOR")))
+
+	agentConf.initialized = true
+	assert.Equal(t, "", GetConfig(ConfName("INVALID")))
+
+	assert.Equal(t, "collector.appoptics.com:443", GetConfig(ConfName("APPOPTICS_COLLECTOR")))
+	assert.Equal(t, "", GetConfig(ConfName("")))
+
+	os.Setenv("APPOPTICS_COLLECTOR", "test.com:12345")
+	Init()
+	assert.Equal(t, "test.com:12345", GetConfig(ConfName("APPOPTICS_COLLECTOR")))
+	os.Unsetenv("APPOPTICS_COLLECTOR")
+	Init()
+	assert.Equal(t, "collector.appoptics.com:443", GetConfig(ConfName("APPOPTICS_COLLECTOR")))
+}

--- a/v1/ao/internal/agent/logging.go
+++ b/v1/ao/internal/agent/logging.go
@@ -32,6 +32,7 @@ const (
 	ERROR
 )
 
+// The string representation of log levels
 var levelStr = []string{
 	DEBUG:   "DEBUG",
 	INFO:    "INFO",
@@ -45,12 +46,14 @@ var (
 	_globalLevel        = &logLevel{LogLevel: _defaultLogLevel}
 )
 
+// SetLevel sets the log level of AppOptics agent
 func (l *logLevel) SetLevel(level LogLevel) {
 	l.Lock()
 	defer l.Unlock()
 	l.LogLevel = level
 }
 
+// Level returns the current log level of AppOptics agent
 func (l *logLevel) Level() LogLevel {
 	l.RLock()
 	defer l.RUnlock()
@@ -62,10 +65,13 @@ var (
 	Level    = _globalLevel.Level
 )
 
+// initLogging initializes the global logger with the configured log level
 func initLogging() {
 	SetLevel(verifyLogLevel(GetConfig(AppOpticsLogLevel)))
 }
 
+// verifyLogLevel verifies if a string correctly represents a valid log level and returns
+// the level in LogLevel type. It will return the default level for invalid arguments
 func verifyLogLevel(level string) (lvl LogLevel) {
 	// We do not want to break backward-compatibility so keep accepting integer values.
 	if i, err := strconv.Atoi(level); err == nil {
@@ -85,7 +91,8 @@ func verifyLogLevel(level string) (lvl LogLevel) {
 	return
 }
 
-// elemOffset is a simple helper function to check if a slice contains a specific element
+// StrToLevel converts a log level in string format (e.g., "DEBUG") to the corresponding log level
+// in LogLevel type. It returns ERROR (the highest level) and an error for invalid log level strings
 func StrToLevel(e string) (LogLevel, error) {
 	offset, err := elemOffset(levelStr, e)
 	if err == nil {
@@ -95,6 +102,7 @@ func StrToLevel(e string) (LogLevel, error) {
 	}
 }
 
+// elemOffset is a simple helper function to check if a slice contains a specific element
 func elemOffset(s []string, e string) (int, error) {
 	for idx, i := range s {
 		if e == i {
@@ -116,14 +124,22 @@ func logIt(level LogLevel, msg string, args []interface{}) {
 	}
 
 	var buffer bytes.Buffer
+	const numberOfLayersToSkip = 2 // layer 1: logIt(), layer 2: its wrappers, e.g., Info()
 
 	var pre string
 	if level == DEBUG {
-		pc, f, l, ok := runtime.Caller(2)
+		// `runtime.Caller()` is called here to get the metadata of the caller of `Caller`:
+		// the program counter, file name, and line number within the file of the corresponding call.
+		// The argument `skip` is the number of stack frames to skip (for example, if skip == 0
+		// you will always get the metadata of `logIt`, which is useless.)
+		// skip = 2 is used here as there are wrappers on top of `logIt` (Info,
+		// Infof, Error, etc). By skipping two layers (logIt and its wrapper), you may get
+		// the information of real callers of the logging functions.
+		pc, file, line, ok := runtime.Caller(numberOfLayersToSkip)
 		if ok {
 			path := strings.Split(runtime.FuncForPC(pc).Name(), ".")
 			name := path[len(path)-1]
-			pre = fmt.Sprintf("%s %s#%d %s(): ", levelStr[level], filepath.Base(f), l, name)
+			pre = fmt.Sprintf("%s %s#%d %s(): ", levelStr[level], filepath.Base(file), line, name)
 		} else {
 			pre = fmt.Sprintf("%s %s#%s %s(): ", levelStr[level], "na", "na", "na")
 		}

--- a/v1/ao/internal/agent/logging.go
+++ b/v1/ao/internal/agent/logging.go
@@ -55,8 +55,8 @@ func elemOffset(s []string, e string) int {
 	return -1
 }
 
-// Log print logs based on the debug level.
-func Log(level DebugLevel, msg string, args ...interface{}) {
+// log print logs based on the debug level.
+func logit(level DebugLevel, msg string, args []interface{}) {
 	if level < debugLevel {
 		return
 	}
@@ -69,9 +69,37 @@ func Log(level DebugLevel, msg string, args ...interface{}) {
 	} else {
 		p = fmt.Sprintf("%s %s#%s %s(): ", dbgLevels[level], "na", "na", "na")
 	}
-	if len(args) == 0 {
-		log.Printf("%s%s", p, msg)
-	} else {
-		log.Printf("%s%s %v", p, msg, args)
+
+	s := msg
+	if msg == "" && len(args) > 0 {
+		s = fmt.Sprint(args...)
+	} else if msg != "" && len(args) > 0 {
+		s = fmt.Sprintf(msg, args...)
 	}
+	log.Print(p + s)
+}
+
+// Log prints the log message with specified level
+func Log(level DebugLevel, msg string, args ...interface{}) {
+	logit(level, msg, args)
+}
+
+// Debug prints the log message in DEBUG level
+func Debug(msg string, args ...interface{}) {
+	logit(DEBUG, msg, args)
+}
+
+// Info prints the log message in INFO level
+func Info(msg string, args ...interface{}) {
+	logit(INFO, msg, args)
+}
+
+// Warning prints the log message in WARNING level
+func Warning(msg string, args ...interface{}) {
+	logit(WARNING, msg, args)
+}
+
+// Error prints the log message in ERROR level
+func Error(msg string, args ...interface{}) {
+	logit(ERROR, msg, args)
 }

--- a/v1/ao/internal/agent/logging.go
+++ b/v1/ao/internal/agent/logging.go
@@ -79,7 +79,7 @@ func verifyLogLevel(level string) (lvl LogLevel) {
 	} else if l, err := StrToLevel(strings.ToUpper(strings.TrimSpace(level))); err == nil {
 		lvl = l
 	} else {
-		Warning("invalid debug level: %s", level)
+		Warningf("invalid debug level: %s", level)
 		lvl = _defaultLogLevel
 	}
 	return
@@ -134,9 +134,9 @@ func logIt(level LogLevel, msg string, args []interface{}) {
 	buffer.WriteString(pre)
 
 	s := msg
-	if msg == "" && len(args) > 0 {
+	if msg == "" {
 		s = fmt.Sprint(args...)
-	} else if msg != "" && len(args) > 0 {
+	} else {
 		s = fmt.Sprintf(msg, args...)
 	}
 	buffer.WriteString(s)
@@ -144,27 +144,57 @@ func logIt(level LogLevel, msg string, args []interface{}) {
 	log.Print(buffer.String())
 }
 
-// Log prints the log message with specified level
-func Log(level LogLevel, msg string, args ...interface{}) {
+// Logf formats the log message with specified args
+// and print it in the specified level
+func Logf(level LogLevel, msg string, args ...interface{}) {
 	logIt(level, msg, args)
 }
 
-// Debug prints the log message in DEBUG level
-func Debug(msg string, args ...interface{}) {
+// Log prints the log message in the specified level
+func Log(level LogLevel, args ...interface{}) {
+	logIt(level, "", args)
+}
+
+// Debugf formats the log message with specified args
+// and print it in the specified level
+func Debugf(msg string, args ...interface{}) {
 	logIt(DEBUG, msg, args)
 }
 
-// Info prints the log message in INFO level
-func Info(msg string, args ...interface{}) {
+// Debug prints the log message in the specified level
+func Debug(args ...interface{}) {
+	logIt(DEBUG, "", args)
+}
+
+// Infof formats the log message with specified args
+// and print it in the specified level
+func Infof(msg string, args ...interface{}) {
 	logIt(INFO, msg, args)
 }
 
-// Warning prints the log message in WARNING level
-func Warning(msg string, args ...interface{}) {
+// Info prints the log message in the specified level
+func Info(args ...interface{}) {
+	logIt(INFO, "", args)
+}
+
+// Warningf formats the log message with specified args
+// and print it in the specified level
+func Warningf(msg string, args ...interface{}) {
 	logIt(WARNING, msg, args)
 }
 
-// Error prints the log message in ERROR level
-func Error(msg string, args ...interface{}) {
+// Warning prints the log message in the specified level
+func Warning(args ...interface{}) {
+	logIt(WARNING, "", args)
+}
+
+// Errorf formats the log message with specified args
+// and print it in the specified level
+func Errorf(msg string, args ...interface{}) {
 	logIt(ERROR, msg, args)
+}
+
+// Error prints the log message in the specified level
+func Error(args ...interface{}) {
+	logIt(ERROR, "", args)
 }

--- a/v1/ao/internal/agent/logging.go
+++ b/v1/ao/internal/agent/logging.go
@@ -117,14 +117,19 @@ func logIt(level LogLevel, msg string, args []interface{}) {
 	var buffer bytes.Buffer
 
 	var pre string
-	pc, f, l, ok := runtime.Caller(2)
-	if ok {
-		path := strings.Split(runtime.FuncForPC(pc).Name(), ".")
-		name := path[len(path)-1]
-		pre = fmt.Sprintf("%s %s#%d %s(): ", levelStr[level], filepath.Base(f), l, name)
-	} else {
-		pre = fmt.Sprintf("%s %s#%s %s(): ", levelStr[level], "na", "na", "na")
+	if level == DEBUG {
+		pc, f, l, ok := runtime.Caller(2)
+		if ok {
+			path := strings.Split(runtime.FuncForPC(pc).Name(), ".")
+			name := path[len(path)-1]
+			pre = fmt.Sprintf("%s %s#%d %s(): ", levelStr[level], filepath.Base(f), l, name)
+		} else {
+			pre = fmt.Sprintf("%s %s#%s %s(): ", levelStr[level], "na", "na", "na")
+		}
+	} else { // avoid expensive reflections in production
+		pre = fmt.Sprintf("%s ", levelStr[level])
 	}
+
 	buffer.WriteString(pre)
 
 	s := msg

--- a/v1/ao/internal/agent/logging.go
+++ b/v1/ao/internal/agent/logging.go
@@ -1,0 +1,77 @@
+package agent
+
+import (
+	"fmt"
+	"log"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// DebugLevel is a type that defines the log level.
+type DebugLevel uint8
+
+// log levels
+const (
+	DEBUG DebugLevel = iota
+	INFO
+	WARNING
+	ERROR
+)
+
+var dbgLevels = []string{
+	DEBUG:   "DEBUG",
+	INFO:    "INFO",
+	WARNING: "WARN",
+	ERROR:   "ERROR",
+}
+
+var debugLevel = DebugLevel(elemOffset(dbgLevels, strings.ToUpper(strings.TrimSpace(defaultDebugLevel))))
+
+func initLogging() {
+	level := GetConfig(AppOpticsDebugLevel)
+	// We do not want to break backward-compatibility so keep accepting integer values.
+	if i, err := strconv.Atoi(level); err == nil {
+		// Protect the debug level from some invalid value, e.g., 1000
+		if i >= len(dbgLevels) {
+			i = len(dbgLevels) - 1
+		}
+		debugLevel = DebugLevel(i)
+	} else if offset := elemOffset(dbgLevels, strings.ToUpper(strings.TrimSpace(level))); offset != -1 {
+		debugLevel = DebugLevel(offset)
+	} else {
+		Log(WARNING, fmt.Sprintf("invalid debug level: %s", level))
+	}
+}
+
+// elemOffset is a simple helper function to check if a slice contains a specific element
+func elemOffset(s []string, e string) int {
+	for idx, i := range s {
+		if e == i {
+			return idx
+		}
+	}
+	return -1
+}
+
+// Log print logs based on the debug level.
+func Log(level DebugLevel, msg string, args ...interface{}) {
+	if level < debugLevel {
+		return
+	}
+	var p string
+	pc, f, l, ok := runtime.Caller(1)
+	if ok {
+		path := strings.Split(runtime.FuncForPC(pc).Name(), ".")
+		name := path[len(path)-1]
+		p = fmt.Sprintf("%s %s#%d %s(): ", dbgLevels[level], filepath.Base(f), l, name)
+	} else {
+		p = fmt.Sprintf("%s %s#%s %s(): ", dbgLevels[level], "na", "na", "na")
+	}
+	if len(args) == 0 {
+		log.Printf("%s%s", p, msg)
+	} else {
+		log.Printf("%s%s %v", p, msg, args)
+	}
+}

--- a/v1/ao/internal/agent/logging.go
+++ b/v1/ao/internal/agent/logging.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2017 Librato, Inc. All rights reserved.
+
 package agent
 
 import (
@@ -113,14 +115,17 @@ func logIt(level LogLevel, msg string, args []interface{}) {
 	}
 
 	var buffer bytes.Buffer
+
+	var pre string
 	pc, f, l, ok := runtime.Caller(2)
 	if ok {
 		path := strings.Split(runtime.FuncForPC(pc).Name(), ".")
 		name := path[len(path)-1]
-		buffer.WriteString(fmt.Sprintf("%s %s#%d %s(): ", levelStr[level], filepath.Base(f), l, name))
+		pre = fmt.Sprintf("%s %s#%d %s(): ", levelStr[level], filepath.Base(f), l, name)
 	} else {
-		buffer.WriteString(fmt.Sprintf("%s %s#%s %s(): ", levelStr[level], "na", "na", "na"))
+		pre = fmt.Sprintf("%s %s#%s %s(): ", levelStr[level], "na", "na", "na")
 	}
+	buffer.WriteString(pre)
 
 	s := msg
 	if msg == "" && len(args) > 0 {
@@ -129,6 +134,7 @@ func logIt(level LogLevel, msg string, args []interface{}) {
 		s = fmt.Sprintf(msg, args...)
 	}
 	buffer.WriteString(s)
+
 	log.Print(buffer.String())
 }
 

--- a/v1/ao/internal/agent/logging.go
+++ b/v1/ao/internal/agent/logging.go
@@ -18,6 +18,7 @@ import (
 type LogLevel uint8
 
 // logLevel is the type for protected log level
+// DO NOT COPY ME
 type logLevel struct {
 	LogLevel
 	sync.RWMutex
@@ -41,7 +42,7 @@ var levelStr = []string{
 // The global log level.
 var (
 	_defaultLogLevel, _ = StrToLevel(defaultLogLevel)
-	_globalLevel        = logLevel{LogLevel: _defaultLogLevel}
+	_globalLevel        = &logLevel{LogLevel: _defaultLogLevel}
 )
 
 func (l *logLevel) SetLevel(level LogLevel) {

--- a/v1/ao/internal/agent/logging_test.go
+++ b/v1/ao/internal/agent/logging_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"sync"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -97,13 +99,19 @@ func TestVerifyLogLevel(t *testing.T) {
 }
 
 func TestSetLevel(t *testing.T) {
+	var wg = &sync.WaitGroup{}
+	wg.Add(100)
 	for i := 0; i < 100; i++ {
-		go func() {
+		go func(wg *sync.WaitGroup) {
 			time.Sleep(time.Millisecond * time.Duration(rand.Intn(5)))
 			SetLevel(LogLevel(rand.Intn(len(levelStr))))
-			Log(ERROR, "hello world")
-		}()
+			Debug("hello world")
+			wg.Done()
+		}(wg)
 	}
+	wg.Wait()
+
 	SetLevel(DEBUG)
-	assert.Equal(t, Level(), DEBUG)
+	Error("", "one", "two", "three")
+	assert.Equal(t, DEBUG, Level())
 }

--- a/v1/ao/internal/agent/logging_test.go
+++ b/v1/ao/internal/agent/logging_test.go
@@ -10,6 +10,8 @@ import (
 
 	"strings"
 
+	"fmt"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -76,4 +78,21 @@ func TestLog(t *testing.T) {
 	str := "hello world"
 	Log(INFO, str)
 	assert.True(t, strings.HasSuffix(buffer.String(), str+"\n"))
+
+	buffer.Reset()
+	str = ""
+	Log(INFO, "")
+	assert.True(t, strings.HasSuffix(buffer.String(), str+"\n"))
+
+	buffer.Reset()
+	str = ""
+	Log(INFO, "", nil)
+	assert.True(t, strings.HasSuffix(buffer.String(), str+"\n"))
+
+	buffer.Reset()
+	str = "hello %s"
+	Log(INFO, "hello %s", nil)
+	fmt.Println("----" + buffer.String() + "----")
+	assert.True(t, strings.HasSuffix(buffer.String(), "hello %!s(<nil>)"+"\n"))
+
 }

--- a/v1/ao/internal/agent/logging_test.go
+++ b/v1/ao/internal/agent/logging_test.go
@@ -1,0 +1,79 @@
+package agent
+
+import (
+	"os"
+	"testing"
+
+	"log"
+
+	"bytes"
+
+	"strings"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDebugLevel(t *testing.T) {
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "DEBUG")
+	Init()
+	assert.EqualValues(t, debugLevel, DebugLevel(0))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "Info")
+	Init()
+	assert.EqualValues(t, debugLevel, DebugLevel(1))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "warn")
+	Init()
+	assert.EqualValues(t, debugLevel, DebugLevel(2))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "erroR")
+	Init()
+	assert.EqualValues(t, debugLevel, DebugLevel(3))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", " erroR  ")
+	Init()
+	assert.EqualValues(t, debugLevel, DebugLevel(3))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "HelloWorld")
+	Init()
+	assert.EqualValues(t, debugLevel, DebugLevel(3))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "0")
+	Init()
+	assert.EqualValues(t, debugLevel, DebugLevel(0))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "1")
+	Init()
+	assert.EqualValues(t, debugLevel, DebugLevel(1))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "2")
+	Init()
+	assert.EqualValues(t, debugLevel, DebugLevel(2))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "3")
+	Init()
+	assert.EqualValues(t, debugLevel, DebugLevel(3))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "4")
+	Init()
+	assert.EqualValues(t, debugLevel, DebugLevel(3))
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "1000")
+	Init()
+	assert.EqualValues(t, debugLevel, DebugLevel(3))
+
+	os.Unsetenv("APPOPTICS_DEBUG_LEVEL")
+	Init()
+	assert.EqualValues(t, debugLevel, DebugLevel(2))
+}
+
+func TestLog(t *testing.T) {
+	var buffer bytes.Buffer
+
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "info")
+	Init()
+	log.SetOutput(&buffer)
+	str := "hello world"
+	Log(INFO, str)
+	assert.True(t, strings.HasSuffix(buffer.String(), str+"\n"))
+}

--- a/v1/ao/internal/agent/logging_test.go
+++ b/v1/ao/internal/agent/logging_test.go
@@ -12,7 +12,8 @@ import (
 
 	"strings"
 
-	"fmt"
+	"math/rand"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -20,55 +21,55 @@ import (
 func TestDebugLevel(t *testing.T) {
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "DEBUG")
 	Init()
-	assert.EqualValues(t, logLevel, LogLevel(0))
+	assert.EqualValues(t, Level(), LogLevel(0))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "Info")
 	Init()
-	assert.EqualValues(t, logLevel, LogLevel(1))
+	assert.EqualValues(t, Level(), LogLevel(1))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "warn")
 	Init()
-	assert.EqualValues(t, logLevel, LogLevel(2))
+	assert.EqualValues(t, Level(), LogLevel(2))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "erroR")
 	Init()
-	assert.EqualValues(t, logLevel, LogLevel(3))
+	assert.EqualValues(t, Level(), LogLevel(3))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", " erroR  ")
 	Init()
-	assert.EqualValues(t, logLevel, LogLevel(3))
+	assert.EqualValues(t, Level(), LogLevel(3))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "HelloWorld")
 	Init()
-	assert.EqualValues(t, logLevel, LogLevel(3))
+	assert.EqualValues(t, Level(), _defaultLogLevel)
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "0")
 	Init()
-	assert.EqualValues(t, logLevel, LogLevel(0))
+	assert.EqualValues(t, Level(), LogLevel(0))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "1")
 	Init()
-	assert.EqualValues(t, logLevel, LogLevel(1))
+	assert.EqualValues(t, Level(), LogLevel(1))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "2")
 	Init()
-	assert.EqualValues(t, logLevel, LogLevel(2))
+	assert.EqualValues(t, Level(), LogLevel(2))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "3")
 	Init()
-	assert.EqualValues(t, logLevel, LogLevel(3))
+	assert.EqualValues(t, Level(), LogLevel(3))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "4")
 	Init()
-	assert.EqualValues(t, logLevel, LogLevel(3))
+	assert.EqualValues(t, Level(), _defaultLogLevel)
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "1000")
 	Init()
-	assert.EqualValues(t, logLevel, LogLevel(3))
+	assert.EqualValues(t, Level(), _defaultLogLevel)
 
 	os.Unsetenv("APPOPTICS_DEBUG_LEVEL")
 	Init()
-	assert.EqualValues(t, logLevel, LogLevel(2))
+	assert.EqualValues(t, Level(), _defaultLogLevel)
 }
 
 func TestLog(t *testing.T) {
@@ -94,7 +95,47 @@ func TestLog(t *testing.T) {
 	buffer.Reset()
 	str = "hello %s"
 	Log(INFO, "hello %s", nil)
-	fmt.Println("----" + buffer.String() + "----")
 	assert.True(t, strings.HasSuffix(buffer.String(), "hello %!s(<nil>)"+"\n"))
 
+}
+
+func TestStrToLevel(t *testing.T) {
+	tests := map[string]LogLevel{
+		"DEBUG": DEBUG,
+		"INFO":  INFO,
+		"WARN":  WARNING,
+		"ERROR": ERROR,
+	}
+	for str, lvl := range tests {
+		l, _ := StrToLevel(str)
+		assert.Equal(t, lvl, l)
+	}
+}
+
+func TestVerifyLogLevel(t *testing.T) {
+	tests := map[string]LogLevel{
+		"DEBUG":   DEBUG,
+		"Debug":   DEBUG,
+		"debug":   DEBUG,
+		" dEbUg ": DEBUG,
+		"INFO":    INFO,
+		"WARN":    WARNING,
+		"ERROR":   ERROR,
+		"ABC":     _defaultLogLevel,
+	}
+	for str, lvl := range tests {
+		assert.Equal(t, lvl, verifyLogLevel(str))
+	}
+}
+
+func TestSetLevel(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		go func() {
+			time.Sleep(time.Millisecond * time.Duration(rand.Intn(5)))
+			SetLevel(LogLevel(rand.Intn(len(levelStr))))
+			Log(ERROR, "hello world")
+		}()
+	}
+	SetLevel(DEBUG)
+	assert.Equal(t, Level(), DEBUG)
 }

--- a/v1/ao/internal/agent/logging_test.go
+++ b/v1/ao/internal/agent/logging_test.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2017 Librato, Inc. All rights reserved.
+
 package agent
 
 import (
@@ -18,55 +20,55 @@ import (
 func TestDebugLevel(t *testing.T) {
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "DEBUG")
 	Init()
-	assert.EqualValues(t, debugLevel, DebugLevel(0))
+	assert.EqualValues(t, logLevel, LogLevel(0))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "Info")
 	Init()
-	assert.EqualValues(t, debugLevel, DebugLevel(1))
+	assert.EqualValues(t, logLevel, LogLevel(1))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "warn")
 	Init()
-	assert.EqualValues(t, debugLevel, DebugLevel(2))
+	assert.EqualValues(t, logLevel, LogLevel(2))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "erroR")
 	Init()
-	assert.EqualValues(t, debugLevel, DebugLevel(3))
+	assert.EqualValues(t, logLevel, LogLevel(3))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", " erroR  ")
 	Init()
-	assert.EqualValues(t, debugLevel, DebugLevel(3))
+	assert.EqualValues(t, logLevel, LogLevel(3))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "HelloWorld")
 	Init()
-	assert.EqualValues(t, debugLevel, DebugLevel(3))
+	assert.EqualValues(t, logLevel, LogLevel(3))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "0")
 	Init()
-	assert.EqualValues(t, debugLevel, DebugLevel(0))
+	assert.EqualValues(t, logLevel, LogLevel(0))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "1")
 	Init()
-	assert.EqualValues(t, debugLevel, DebugLevel(1))
+	assert.EqualValues(t, logLevel, LogLevel(1))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "2")
 	Init()
-	assert.EqualValues(t, debugLevel, DebugLevel(2))
+	assert.EqualValues(t, logLevel, LogLevel(2))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "3")
 	Init()
-	assert.EqualValues(t, debugLevel, DebugLevel(3))
+	assert.EqualValues(t, logLevel, LogLevel(3))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "4")
 	Init()
-	assert.EqualValues(t, debugLevel, DebugLevel(3))
+	assert.EqualValues(t, logLevel, LogLevel(3))
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "1000")
 	Init()
-	assert.EqualValues(t, debugLevel, DebugLevel(3))
+	assert.EqualValues(t, logLevel, LogLevel(3))
 
 	os.Unsetenv("APPOPTICS_DEBUG_LEVEL")
 	Init()
-	assert.EqualValues(t, debugLevel, DebugLevel(2))
+	assert.EqualValues(t, logLevel, LogLevel(2))
 }
 
 func TestLog(t *testing.T) {

--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -300,7 +300,7 @@ func newContext(sampled bool) Context {
 	ctx := &oboeContext{txCtx: &transactionContext{}}
 	ctx.metadata.Init()
 	if err := ctx.metadata.SetRandom(); err != nil {
-		agent.Info("AppOptics rand.Read error: %v", err)
+		agent.Infof("AppOptics rand.Read error: %v", err)
 		return &nullContext{}
 	}
 	ctx.SetSampled(sampled)

--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"sync"
 
-	"fmt"
-
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent"
 )
 
@@ -302,7 +300,7 @@ func newContext(sampled bool) Context {
 	ctx := &oboeContext{txCtx: &transactionContext{}}
 	ctx.metadata.Init()
 	if err := ctx.metadata.SetRandom(); err != nil {
-		agent.Log(agent.INFO, fmt.Sprintf("AppOptics rand.Read error: %v", err))
+		agent.Info("AppOptics rand.Read error: %v", err)
 		return &nullContext{}
 	}
 	ctx.SetSampled(sampled)
@@ -325,14 +323,14 @@ func NewContext(layer, mdStr string, reportEntry bool, cb func() map[string]inte
 	if mdStr != "" {
 		var err error
 		if ctx, err = newContextFromMetadataString(mdStr); err != nil {
-			agent.Log(agent.INFO, "passed in x-trace seems invalid, ignoring")
+			agent.Info("passed in x-trace seems invalid, ignoring")
 		} else if ctx.GetVersion() != xtrCurrentVersion {
-			agent.Log(agent.INFO, "passed in x-trace has wrong version, ignoring")
+			agent.Info("passed in x-trace has wrong version, ignoring")
 		} else if ctx.IsSampled() {
 			traced = true
 			addCtxEdge = true
 		} else {
-			agent.Log(agent.INFO, "passed in x-trace indicates that request is not being sampled")
+			agent.Info("passed in x-trace indicates that request is not being sampled")
 			return ctx, true
 		}
 	}

--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -237,14 +237,14 @@ func (md *oboeMetadata) ToString() (string, error) {
 	}
 	// encode as hex
 	enc := make([]byte, 2*result)
-	len := hex.Encode(enc, buf[:result])
-	return strings.ToUpper(string(enc[:len])), nil
+	l := hex.Encode(enc, buf[:result])
+	return strings.ToUpper(string(enc[:l])), nil
 }
 
 func (md *oboeMetadata) opString() string {
 	enc := make([]byte, 2*md.opLen)
-	len := hex.Encode(enc, md.ids.opID[:md.opLen])
-	return strings.ToUpper(string(enc[:len]))
+	l := hex.Encode(enc, md.ids.opID[:md.opLen])
+	return strings.ToUpper(string(enc[:l]))
 }
 
 func (md *oboeMetadata) isSampled() bool {

--- a/v1/ao/internal/reporter/context_test.go
+++ b/v1/ao/internal/reporter/context_test.go
@@ -65,8 +65,8 @@ func TestMetadata(t *testing.T) {
 	bufS := make([]byte, 128)          // buffer to pack
 	pkcnt, pkerr = mdS.Pack(bufS)
 	assert.NoError(t, pkerr)
-	assert.Equal(t, (2 + shortTaskLen + 8), pkcnt) // pack buf
-	mdSStr, err := mdS.ToString()                  // encode as string
+	assert.Equal(t, 2+shortTaskLen+8, pkcnt) // pack buf
+	mdSStr, err := mdS.ToString()            // encode as string
 	assert.NoError(t, err)
 	t.Logf("mdS: %s", mdSStr)                   // log 50 char hex string
 	assert.Len(t, mdSStr, (2+shortTaskLen+8)*2) // check len=(1 + 12 + 8)*2

--- a/v1/ao/internal/reporter/event.go
+++ b/v1/ao/internal/reporter/event.go
@@ -167,7 +167,7 @@ func (e *event) AddKV(key, value interface{}) error {
 	// load key name
 	k, isStr := key.(string)
 	if !isStr {
-		return fmt.Errorf("Key %v (type %T) not a string", k, k)
+		return fmt.Errorf("key %v (type %T) not a string", k, k)
 	}
 	// load value and add KV to event
 	switch v := value.(type) {

--- a/v1/ao/internal/reporter/event.go
+++ b/v1/ao/internal/reporter/event.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
+
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent"
 )
 
 type event struct {
@@ -260,10 +262,8 @@ func (e *event) AddKV(key, value interface{}) error {
 			e.AddBool(k, *v)
 		}
 	default:
-		// silently skip unsupported value type
-		if debugLog {
-			OboeLog(DEBUG, "Unrecognized Event key %v val %v", k, v)
-		}
+		s := fmt.Sprintf("Ignoring unrecognized Event key %v val %v valType %T", k, v, v)
+		agent.Log(agent.DEBUG, s)
 	}
 	return nil
 }

--- a/v1/ao/internal/reporter/event.go
+++ b/v1/ao/internal/reporter/event.go
@@ -262,8 +262,7 @@ func (e *event) AddKV(key, value interface{}) error {
 			e.AddBool(k, *v)
 		}
 	default:
-		s := fmt.Sprintf("Ignoring unrecognized Event key %v val %v valType %T", k, v, v)
-		agent.Log(agent.DEBUG, s)
+		agent.Debug("Ignoring unrecognized Event key %v val %v valType %T", k, v, v)
 	}
 	return nil
 }

--- a/v1/ao/internal/reporter/event.go
+++ b/v1/ao/internal/reporter/event.go
@@ -262,7 +262,7 @@ func (e *event) AddKV(key, value interface{}) error {
 			e.AddBool(k, *v)
 		}
 	default:
-		agent.Debug("Ignoring unrecognized Event key %v val %v valType %T", k, v, v)
+		agent.Debugf("Ignoring unrecognized Event key %v val %v valType %T", k, v, v)
 	}
 	return nil
 }

--- a/v1/ao/internal/reporter/metrics.go
+++ b/v1/ao/internal/reporter/metrics.go
@@ -148,6 +148,7 @@ func init() {
 	pEnv := "APPOPTICS_HISTOGRAM_PRECISION"
 	precision := os.Getenv(pEnv)
 	if precision != "" {
+		OboeLog(INFO, fmt.Sprintf("Non-default APPOPTICS_HISTOGRAM_PRECISION: %s", precision))
 		if p, err := strconv.Atoi(precision); err == nil {
 			if p >= 0 && p <= 5 {
 				metricsHTTPHistograms.precision = p

--- a/v1/ao/internal/reporter/metrics.go
+++ b/v1/ao/internal/reporter/metrics.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/hdrhist"
 )
 
@@ -148,16 +149,16 @@ func init() {
 	pEnv := "APPOPTICS_HISTOGRAM_PRECISION"
 	precision := os.Getenv(pEnv)
 	if precision != "" {
-		OboeLog(INFO, fmt.Sprintf("Non-default APPOPTICS_HISTOGRAM_PRECISION: %s", precision))
+		agent.Log(agent.INFO, fmt.Sprintf("Non-default APPOPTICS_HISTOGRAM_PRECISION: %s", precision))
 		if p, err := strconv.Atoi(precision); err == nil {
 			if p >= 0 && p <= 5 {
 				metricsHTTPHistograms.precision = p
 			} else {
-				OboeLog(ERROR, fmt.Sprintf(
+				agent.Log(agent.ERROR, fmt.Sprintf(
 					"value of %v must be between 0 and 5: %v", pEnv, precision))
 			}
 		} else {
-			OboeLog(ERROR, fmt.Sprintf(
+			agent.Log(agent.ERROR, fmt.Sprintf(
 				"value of %v is not an int: %v", pEnv, precision))
 		}
 	}
@@ -507,7 +508,7 @@ func addMetricsValue(bbuf *bsonBuffer, index *int, name string, value interface{
 	start := bsonAppendStartObject(bbuf, strconv.Itoa(*index))
 	defer func() {
 		if err := recover(); err != nil {
-			OboeLog(ERROR, fmt.Sprintf("%v", err))
+			agent.Log(agent.ERROR, fmt.Sprintf("%v", err))
 		}
 	}()
 
@@ -680,7 +681,7 @@ func recordHistogram(hi *histograms, name string, duration time.Duration) {
 	defer func() {
 		hi.lock.Unlock()
 		if err := recover(); err != nil {
-			OboeLog(ERROR, fmt.Sprintf("Failed to record histogram: %v", err))
+			agent.Log(agent.ERROR, fmt.Sprintf("Failed to record histogram: %v", err))
 		}
 	}()
 
@@ -758,7 +759,7 @@ func addHistogramToBSON(bbuf *bsonBuffer, index *int, h *histogram) {
 	// get 64-base encoded representation of the histogram
 	data, err := hdrhist.EncodeCompressed(h.hist)
 	if err != nil {
-		OboeLog(ERROR, fmt.Sprintf("Failed to encode histogram: %v", err))
+		agent.Log(agent.ERROR, fmt.Sprintf("Failed to encode histogram: %v", err))
 		return
 	}
 

--- a/v1/ao/internal/reporter/metrics.go
+++ b/v1/ao/internal/reporter/metrics.go
@@ -3,7 +3,6 @@
 package reporter
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -149,17 +148,15 @@ func init() {
 	pEnv := "APPOPTICS_HISTOGRAM_PRECISION"
 	precision := os.Getenv(pEnv)
 	if precision != "" {
-		agent.Log(agent.INFO, fmt.Sprintf("Non-default APPOPTICS_HISTOGRAM_PRECISION: %s", precision))
+		agent.Info("Non-default APPOPTICS_HISTOGRAM_PRECISION: %s", precision)
 		if p, err := strconv.Atoi(precision); err == nil {
 			if p >= 0 && p <= 5 {
 				metricsHTTPHistograms.precision = p
 			} else {
-				agent.Log(agent.ERROR, fmt.Sprintf(
-					"value of %v must be between 0 and 5: %v", pEnv, precision))
+				agent.Error("value of %v must be between 0 and 5: %v", pEnv, precision)
 			}
 		} else {
-			agent.Log(agent.ERROR, fmt.Sprintf(
-				"value of %v is not an int: %v", pEnv, precision))
+			agent.Error("value of %v is not an int: %v", pEnv, precision)
 		}
 	}
 }
@@ -508,7 +505,7 @@ func addMetricsValue(bbuf *bsonBuffer, index *int, name string, value interface{
 	start := bsonAppendStartObject(bbuf, strconv.Itoa(*index))
 	defer func() {
 		if err := recover(); err != nil {
-			agent.Log(agent.ERROR, fmt.Sprintf("%v", err))
+			agent.Error("%v", err)
 		}
 	}()
 
@@ -681,7 +678,7 @@ func recordHistogram(hi *histograms, name string, duration time.Duration) {
 	defer func() {
 		hi.lock.Unlock()
 		if err := recover(); err != nil {
-			agent.Log(agent.ERROR, fmt.Sprintf("Failed to record histogram: %v", err))
+			agent.Error("Failed to record histogram: %v", err)
 		}
 	}()
 
@@ -759,7 +756,7 @@ func addHistogramToBSON(bbuf *bsonBuffer, index *int, h *histogram) {
 	// get 64-base encoded representation of the histogram
 	data, err := hdrhist.EncodeCompressed(h.hist)
 	if err != nil {
-		agent.Log(agent.ERROR, fmt.Sprintf("Failed to encode histogram: %v", err))
+		agent.Error("Failed to encode histogram: %v", err)
 		return
 	}
 

--- a/v1/ao/internal/reporter/metrics.go
+++ b/v1/ao/internal/reporter/metrics.go
@@ -148,15 +148,15 @@ func init() {
 	pEnv := "APPOPTICS_HISTOGRAM_PRECISION"
 	precision := os.Getenv(pEnv)
 	if precision != "" {
-		agent.Info("Non-default APPOPTICS_HISTOGRAM_PRECISION: %s", precision)
+		agent.Infof("Non-default APPOPTICS_HISTOGRAM_PRECISION: %s", precision)
 		if p, err := strconv.Atoi(precision); err == nil {
 			if p >= 0 && p <= 5 {
 				metricsHTTPHistograms.precision = p
 			} else {
-				agent.Error("value of %v must be between 0 and 5: %v", pEnv, precision)
+				agent.Errorf("value of %v must be between 0 and 5: %v", pEnv, precision)
 			}
 		} else {
-			agent.Error("value of %v is not an int: %v", pEnv, precision)
+			agent.Errorf("value of %v is not an int: %v", pEnv, precision)
 		}
 	}
 }
@@ -505,7 +505,7 @@ func addMetricsValue(bbuf *bsonBuffer, index *int, name string, value interface{
 	start := bsonAppendStartObject(bbuf, strconv.Itoa(*index))
 	defer func() {
 		if err := recover(); err != nil {
-			agent.Error("%v", err)
+			agent.Errorf("%v", err)
 		}
 	}()
 
@@ -678,7 +678,7 @@ func recordHistogram(hi *histograms, name string, duration time.Duration) {
 	defer func() {
 		hi.lock.Unlock()
 		if err := recover(); err != nil {
-			agent.Error("Failed to record histogram: %v", err)
+			agent.Errorf("Failed to record histogram: %v", err)
 		}
 	}()
 
@@ -756,7 +756,7 @@ func addHistogramToBSON(bbuf *bsonBuffer, index *int, h *histogram) {
 	// get 64-base encoded representation of the histogram
 	data, err := hdrhist.EncodeCompressed(h.hist)
 	if err != nil {
-		agent.Error("Failed to encode histogram: %v", err)
+		agent.Errorf("Failed to encode histogram: %v", err)
 		return
 	}
 

--- a/v1/ao/internal/reporter/metrics_linux.go
+++ b/v1/ao/internal/reporter/metrics_linux.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent"
 )
 
 // gets and appends UnameSysName/UnameVersion to a BSON buffer
@@ -72,7 +74,7 @@ func isPhysicalInterface(ifname string) bool {
 	fn := "/sys/class/net/" + ifname
 	link, err := os.Readlink(fn)
 	if err != nil {
-		OboeLog(ERROR, fmt.Sprintf("cannot readlink %s", fn))
+		agent.Log(agent.ERROR, fmt.Sprintf("cannot readlink %s", fn))
 		return false
 	}
 	if strings.Contains(link, "/virtual/") {

--- a/v1/ao/internal/reporter/metrics_linux.go
+++ b/v1/ao/internal/reporter/metrics_linux.go
@@ -73,7 +73,7 @@ func isPhysicalInterface(ifname string) bool {
 	fn := "/sys/class/net/" + ifname
 	link, err := os.Readlink(fn)
 	if err != nil {
-		agent.Error("cannot readlink %s", fn)
+		agent.Errorf("cannot readlink %s", fn)
 		return false
 	}
 	if strings.Contains(link, "/virtual/") {

--- a/v1/ao/internal/reporter/metrics_linux.go
+++ b/v1/ao/internal/reporter/metrics_linux.go
@@ -5,7 +5,6 @@
 package reporter
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -74,7 +73,7 @@ func isPhysicalInterface(ifname string) bool {
 	fn := "/sys/class/net/" + ifname
 	link, err := os.Readlink(fn)
 	if err != nil {
-		agent.Log(agent.ERROR, fmt.Sprintf("cannot readlink %s", fn))
+		agent.Error("cannot readlink %s", fn)
 		return false
 	}
 	if strings.Contains(link, "/virtual/") {

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -63,6 +63,9 @@ func init() {
 func readEnvSettings() {
 	// Configure tracing mode setting using environment variable
 	mode := strings.ToLower(os.Getenv("APPOPTICS_TRACING_MODE"))
+	if mode != "" {
+		OboeLog(INFO, fmt.Sprintf("Non-default APPOPTICS_TRACING_MODE: %s", mode))
+	}
 	switch mode {
 	case "always":
 		fallthrough
@@ -73,6 +76,7 @@ func readEnvSettings() {
 	}
 
 	if level := os.Getenv("APPOPTICS_DEBUG_LEVEL"); level != "" {
+		OboeLog(INFO, fmt.Sprintf("Non-default APPOPTICS_DEBUG_LEVEL: %s", level))
 		// We do not want to break backward-compatibility so keep accepting integer values.
 		if i, err := strconv.Atoi(level); err == nil {
 			// Protect the debug level from some invalid value, e.g., 1000
@@ -89,6 +93,9 @@ func readEnvSettings() {
 
 	// Prepend the domain name onto transaction names
 	prepend := os.Getenv("APPOPTICS_PREPEND_DOMAIN")
+	if prepend != "" {
+		OboeLog(INFO, fmt.Sprintf("Non-default APPOPTICS_PREPEND_DOMAIN: %s", prepend))
+	}
 	if strings.ToLower(prepend) == "true" {
 		prependDomainForTransactionName = true
 	} else {

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -6,7 +6,6 @@ package reporter
 
 import (
 	"encoding/binary"
-	"fmt"
 	"math"
 	"math/rand"
 	"runtime"
@@ -87,7 +86,7 @@ func sendInitMessage() {
 		// create new event from context
 		e, err := c.newEvent("single", "go")
 		if err != nil {
-			agent.Log(agent.ERROR, "Error while creating the init message")
+			agent.Error("Error while creating the init message")
 		}
 
 		e.AddKV("__Init", 1)
@@ -168,7 +167,7 @@ func oboeSampleRequest(layer string, traced bool) (bool, int, sampleSource) {
 	var setting *oboeSettings
 	var ok bool
 	if setting, ok = getSetting(layer); !ok {
-		agent.Log(agent.DEBUG, fmt.Sprintf("Sampling disabled for %v until valid settings are retrieved.", layer))
+		agent.Debug("Sampling disabled for %v until valid settings are retrieved.", layer)
 		return false, 0, SAMPLE_SOURCE_NONE
 	}
 
@@ -207,7 +206,7 @@ func oboeSampleRequest(layer string, traced bool) (bool, int, sampleSource) {
 
 	retval = setting.bucket.count(retval, traced, doRateLimiting)
 
-	agent.Log(agent.DEBUG, fmt.Sprintf("Sampling with rate=%v, source=%v", sampleRate, sampleSource))
+	agent.Debug("Sampling with rate=%v, source=%v", sampleRate, sampleSource)
 	return retval, sampleRate, sampleSource
 }
 
@@ -254,7 +253,7 @@ func updateSetting(sType int32, layer string, flags []byte, value int64, ttl int
 		setting.bucket.capacity = bucketCapacity
 	} else {
 		setting.bucket.capacity = 0
-		agent.Log(agent.WARNING, fmt.Sprintf("Invalid bucket capacity (%v). Using %v.", bucketCapacity, 0))
+		agent.Warning("Invalid bucket capacity (%v). Using %v.", bucketCapacity, 0)
 	}
 	if setting.bucket.available > setting.bucket.capacity {
 		setting.bucket.available = setting.bucket.capacity
@@ -263,7 +262,7 @@ func updateSetting(sType int32, layer string, flags []byte, value int64, ttl int
 		setting.bucket.ratePerSec = bucketRatePerSec
 	} else {
 		setting.bucket.ratePerSec = 0
-		agent.Log(agent.WARNING, fmt.Sprintf("Invalid bucket rate (%v). Using %v.", bucketRatePerSec, 0))
+		agent.Warning("Invalid bucket rate (%v). Using %v.", bucketRatePerSec, 0)
 	}
 	setting.bucket.lock.Unlock()
 }
@@ -295,7 +294,7 @@ func getSetting(layer string) (*oboeSettings, bool) {
 
 func shouldSample(sampleRate int) bool {
 	retval := sampleRate == maxSamplingRate || rand.Intn(maxSamplingRate) <= sampleRate
-	agent.Log(agent.DEBUG, fmt.Sprintf("shouldSample(%v) => %v", sampleRate, retval))
+	agent.Debug("shouldSample(%v) => %v", sampleRate, retval)
 	return retval
 }
 

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -167,7 +167,7 @@ func oboeSampleRequest(layer string, traced bool) (bool, int, sampleSource) {
 	var setting *oboeSettings
 	var ok bool
 	if setting, ok = getSetting(layer); !ok {
-		agent.Debug("Sampling disabled for %v until valid settings are retrieved.", layer)
+		agent.Debugf("Sampling disabled for %v until valid settings are retrieved.", layer)
 		return false, 0, SAMPLE_SOURCE_NONE
 	}
 
@@ -206,7 +206,7 @@ func oboeSampleRequest(layer string, traced bool) (bool, int, sampleSource) {
 
 	retval = setting.bucket.count(retval, traced, doRateLimiting)
 
-	agent.Debug("Sampling with rate=%v, source=%v", sampleRate, sampleSource)
+	agent.Debugf("Sampling with rate=%v, source=%v", sampleRate, sampleSource)
 	return retval, sampleRate, sampleSource
 }
 
@@ -253,7 +253,7 @@ func updateSetting(sType int32, layer string, flags []byte, value int64, ttl int
 		setting.bucket.capacity = bucketCapacity
 	} else {
 		setting.bucket.capacity = 0
-		agent.Warning("Invalid bucket capacity (%v). Using %v.", bucketCapacity, 0)
+		agent.Warningf("Invalid bucket capacity (%v). Using %v.", bucketCapacity, 0)
 	}
 	if setting.bucket.available > setting.bucket.capacity {
 		setting.bucket.available = setting.bucket.capacity
@@ -262,7 +262,7 @@ func updateSetting(sType int32, layer string, flags []byte, value int64, ttl int
 		setting.bucket.ratePerSec = bucketRatePerSec
 	} else {
 		setting.bucket.ratePerSec = 0
-		agent.Warning("Invalid bucket rate (%v). Using %v.", bucketRatePerSec, 0)
+		agent.Warningf("Invalid bucket rate (%v). Using %v.", bucketRatePerSec, 0)
 	}
 	setting.bucket.lock.Unlock()
 }
@@ -294,7 +294,7 @@ func getSetting(layer string) (*oboeSettings, bool) {
 
 func shouldSample(sampleRate int) bool {
 	retval := sampleRate == maxSamplingRate || rand.Intn(maxSamplingRate) <= sampleRate
-	agent.Debug("shouldSample(%v) => %v", sampleRate, retval)
+	agent.Debugf("shouldSample(%v) => %v", sampleRate, retval)
 	return retval
 }
 

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -9,13 +9,13 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"os"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent"
 )
 
 // Current settings configuration
@@ -62,10 +62,7 @@ func init() {
 
 func readEnvSettings() {
 	// Configure tracing mode setting using environment variable
-	mode := strings.ToLower(os.Getenv("APPOPTICS_TRACING_MODE"))
-	if mode != "" {
-		OboeLog(INFO, fmt.Sprintf("Non-default APPOPTICS_TRACING_MODE: %s", mode))
-	}
+	mode := agent.GetConfig(agent.AppOpticsTracingMode)
 	switch mode {
 	case "always":
 		fallthrough
@@ -75,28 +72,9 @@ func readEnvSettings() {
 		globalSettingsCfg.tracingMode = TRACE_NEVER
 	}
 
-	if level := os.Getenv("APPOPTICS_DEBUG_LEVEL"); level != "" {
-		OboeLog(INFO, fmt.Sprintf("Non-default APPOPTICS_DEBUG_LEVEL: %s", level))
-		// We do not want to break backward-compatibility so keep accepting integer values.
-		if i, err := strconv.Atoi(level); err == nil {
-			// Protect the debug level from some invalid value, e.g., 1000
-			if i >= len(dbgLevels) {
-				i = len(dbgLevels) - 1
-			}
-			debugLevel = DebugLevel(i)
-		} else if offset := ElemOffset(dbgLevels, strings.ToUpper(strings.TrimSpace(level))); offset != -1 {
-			debugLevel = DebugLevel(offset)
-		} else {
-			OboeLog(WARNING, fmt.Sprintf("invalid debug level: %s", level))
-		}
-	}
-
 	// Prepend the domain name onto transaction names
-	prepend := os.Getenv("APPOPTICS_PREPEND_DOMAIN")
-	if prepend != "" {
-		OboeLog(INFO, fmt.Sprintf("Non-default APPOPTICS_PREPEND_DOMAIN: %s", prepend))
-	}
-	if strings.ToLower(prepend) == "true" {
+	prepend := agent.GetConfig(agent.AppOpticsPrependDomain)
+	if prepend == "true" {
 		prependDomainForTransactionName = true
 	} else {
 		prependDomainForTransactionName = false
@@ -109,7 +87,7 @@ func sendInitMessage() {
 		// create new event from context
 		e, err := c.newEvent("single", "go")
 		if err != nil {
-			OboeLog(ERROR, "Error while creating the init message")
+			agent.Log(agent.ERROR, "Error while creating the init message")
 		}
 
 		e.AddKV("__Init", 1)
@@ -190,7 +168,7 @@ func oboeSampleRequest(layer string, traced bool) (bool, int, sampleSource) {
 	var setting *oboeSettings
 	var ok bool
 	if setting, ok = getSetting(layer); !ok {
-		OboeLog(DEBUG, fmt.Sprintf("Sampling disabled for %v until valid settings are retrieved.", layer))
+		agent.Log(agent.DEBUG, fmt.Sprintf("Sampling disabled for %v until valid settings are retrieved.", layer))
 		return false, 0, SAMPLE_SOURCE_NONE
 	}
 
@@ -229,7 +207,7 @@ func oboeSampleRequest(layer string, traced bool) (bool, int, sampleSource) {
 
 	retval = setting.bucket.count(retval, traced, doRateLimiting)
 
-	OboeLog(DEBUG, fmt.Sprintf("Sampling with rate=%v, source=%v", sampleRate, sampleSource))
+	agent.Log(agent.DEBUG, fmt.Sprintf("Sampling with rate=%v, source=%v", sampleRate, sampleSource))
 	return retval, sampleRate, sampleSource
 }
 
@@ -276,7 +254,7 @@ func updateSetting(sType int32, layer string, flags []byte, value int64, ttl int
 		setting.bucket.capacity = bucketCapacity
 	} else {
 		setting.bucket.capacity = 0
-		OboeLog(WARNING, fmt.Sprintf("Invalid bucket capacity (%v). Using %v.", bucketCapacity, 0))
+		agent.Log(agent.WARNING, fmt.Sprintf("Invalid bucket capacity (%v). Using %v.", bucketCapacity, 0))
 	}
 	if setting.bucket.available > setting.bucket.capacity {
 		setting.bucket.available = setting.bucket.capacity
@@ -285,7 +263,7 @@ func updateSetting(sType int32, layer string, flags []byte, value int64, ttl int
 		setting.bucket.ratePerSec = bucketRatePerSec
 	} else {
 		setting.bucket.ratePerSec = 0
-		OboeLog(WARNING, fmt.Sprintf("Invalid bucket rate (%v). Using %v.", bucketRatePerSec, 0))
+		agent.Log(agent.WARNING, fmt.Sprintf("Invalid bucket rate (%v). Using %v.", bucketRatePerSec, 0))
 	}
 	setting.bucket.lock.Unlock()
 }
@@ -317,7 +295,7 @@ func getSetting(layer string) (*oboeSettings, bool) {
 
 func shouldSample(sampleRate int) bool {
 	retval := sampleRate == maxSamplingRate || rand.Intn(maxSamplingRate) <= sampleRate
-	OboeLog(DEBUG, fmt.Sprintf("shouldSample(%v) => %v", sampleRate, retval))
+	agent.Log(agent.DEBUG, fmt.Sprintf("shouldSample(%v) => %v", sampleRate, retval))
 	return retval
 }
 

--- a/v1/ao/internal/reporter/oboe_test.go
+++ b/v1/ao/internal/reporter/oboe_test.go
@@ -13,6 +13,7 @@ import (
 
 	"gopkg.in/mgo.v2/bson"
 
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent"
 	g "github.com/appoptics/appoptics-apm-go/v1/ao/internal/graphtest"
 	"github.com/stretchr/testify/assert"
 )
@@ -411,75 +412,21 @@ func TestOboeTracingMode(t *testing.T) {
 	r := SetTestReporter()
 
 	os.Setenv("APPOPTICS_TRACING_MODE", "ALWAYS")
+	agent.Init()
 	readEnvSettings()
 	assert.EqualValues(t, globalSettingsCfg.tracingMode, 1) // C.OBOE_TRACE_ALWAYS
 
 	os.Setenv("APPOPTICS_TRACING_MODE", "never")
+	agent.Init()
 	readEnvSettings()
 	assert.EqualValues(t, globalSettingsCfg.tracingMode, 0) // C.OBOE_TRACE_NEVER
 	ok, _, _ := oboeSampleRequest("myLayer", false)
 	assert.False(t, ok)
 
 	os.Setenv("APPOPTICS_TRACING_MODE", "")
+	agent.Init()
 	readEnvSettings()
 	assert.EqualValues(t, globalSettingsCfg.tracingMode, 1)
 
 	r.Close(0)
-}
-
-func TestDebugLevel(t *testing.T) {
-	r := SetTestReporter()
-	defer r.Close(0)
-
-	os.Setenv("APPOPTICS_DEBUG_LEVEL", "DEBUG")
-	readEnvSettings()
-	assert.EqualValues(t, debugLevel, DebugLevel(0))
-
-	os.Setenv("APPOPTICS_DEBUG_LEVEL", "Info")
-	readEnvSettings()
-	assert.EqualValues(t, debugLevel, DebugLevel(1))
-
-	os.Setenv("APPOPTICS_DEBUG_LEVEL", "warn")
-	readEnvSettings()
-	assert.EqualValues(t, debugLevel, DebugLevel(2))
-
-	os.Setenv("APPOPTICS_DEBUG_LEVEL", "erroR")
-	readEnvSettings()
-	assert.EqualValues(t, debugLevel, DebugLevel(3))
-
-	os.Setenv("APPOPTICS_DEBUG_LEVEL", " erroR  ")
-	readEnvSettings()
-	assert.EqualValues(t, debugLevel, DebugLevel(3))
-
-	os.Setenv("APPOPTICS_DEBUG_LEVEL", "HelloWorld")
-	readEnvSettings()
-	assert.EqualValues(t, debugLevel, DebugLevel(3))
-
-	os.Setenv("APPOPTICS_DEBUG_LEVEL", "0")
-	readEnvSettings()
-	assert.EqualValues(t, debugLevel, DebugLevel(0))
-
-	os.Setenv("APPOPTICS_DEBUG_LEVEL", "1")
-	readEnvSettings()
-	assert.EqualValues(t, debugLevel, DebugLevel(1))
-
-	os.Setenv("APPOPTICS_DEBUG_LEVEL", "2")
-	readEnvSettings()
-	assert.EqualValues(t, debugLevel, DebugLevel(2))
-
-	os.Setenv("APPOPTICS_DEBUG_LEVEL", "3")
-	readEnvSettings()
-	assert.EqualValues(t, debugLevel, DebugLevel(3))
-
-	os.Setenv("APPOPTICS_DEBUG_LEVEL", "4")
-	readEnvSettings()
-	assert.EqualValues(t, debugLevel, DebugLevel(3))
-
-	os.Setenv("APPOPTICS_DEBUG_LEVEL", "1000")
-	readEnvSettings()
-	assert.EqualValues(t, debugLevel, DebugLevel(3))
-
-	os.Unsetenv("APPOPTICS_DEBUG_LEVEL")
-	readEnvSettings()
-	assert.EqualValues(t, debugLevel, DebugLevel(3))
 }

--- a/v1/ao/internal/reporter/reporter.go
+++ b/v1/ao/internal/reporter/reporter.go
@@ -52,8 +52,7 @@ func (r *nullReporter) reportSpan(span SpanMessage) error             { return n
 // can be overridden via APPOPTICS_REPORTER
 func init() {
 	cacheHostname(osHostnamer{})
-	r := agent.GetConfig(agent.AppOpticsReporter)
-	setGlobalReporter(r)
+	setGlobalReporter(agent.GetConfig(agent.AppOpticsReporter))
 	sendInitMessage()
 }
 
@@ -81,7 +80,7 @@ func ReportSpan(span SpanMessage) error {
 func cacheHostname(hn hostnamer) {
 	h, err := hn.Hostname()
 	if err != nil {
-		agent.Error("Unable to get hostname, AppOptics tracing disabled: %v", err)
+		agent.Errorf("Unable to get hostname, AppOptics tracing disabled: %v", err)
 		reportingDisabled = true
 	}
 	cachedHostname = h

--- a/v1/ao/internal/reporter/reporter.go
+++ b/v1/ao/internal/reporter/reporter.go
@@ -81,7 +81,7 @@ func ReportSpan(span SpanMessage) error {
 func cacheHostname(hn hostnamer) {
 	h, err := hn.Hostname()
 	if err != nil {
-		agent.Log(agent.ERROR, "Unable to get hostname, AppOptics tracing disabled: %v", err)
+		agent.Error("Unable to get hostname, AppOptics tracing disabled: %v", err)
 		reportingDisabled = true
 	}
 	cachedHostname = h
@@ -94,17 +94,17 @@ func cacheHostname(hn hostnamer) {
 // returns	error if invalid context or event
 func prepareEvent(ctx *oboeContext, e *event) error {
 	if ctx == nil || e == nil {
-		return errors.New("Invalid context, event")
+		return errors.New("invalid context, event")
 	}
 
 	// The context metadata must have the same task_id as the event.
 	if !bytes.Equal(ctx.metadata.ids.taskID, e.metadata.ids.taskID) {
-		return errors.New("Invalid event, different task_id from context")
+		return errors.New("invalid event, different task_id from context")
 	}
 
 	// The context metadata must have a different op_id than the event.
 	if bytes.Equal(ctx.metadata.ids.opID, e.metadata.ids.opID) {
-		return errors.New("Invalid event, same as context")
+		return errors.New("invalid event, same as context")
 	}
 
 	us := time.Now().UnixNano() / 1000

--- a/v1/ao/internal/reporter/reporter.go
+++ b/v1/ao/internal/reporter/reporter.go
@@ -5,10 +5,11 @@ package reporter
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent"
 )
 
 // defines what methods a reporter should offer (internal to reporter package)
@@ -51,10 +52,7 @@ func (r *nullReporter) reportSpan(span SpanMessage) error             { return n
 // can be overridden via APPOPTICS_REPORTER
 func init() {
 	cacheHostname(osHostnamer{})
-	r := os.Getenv("APPOPTICS_REPORTER")
-	if r != "" {
-		OboeLog(INFO, fmt.Sprintf("Non-default APPOPTICS_REPORTER: %s", r))
-	}
+	r := agent.GetConfig(agent.AppOpticsReporter)
 	setGlobalReporter(r)
 	sendInitMessage()
 }
@@ -83,9 +81,7 @@ func ReportSpan(span SpanMessage) error {
 func cacheHostname(hn hostnamer) {
 	h, err := hn.Hostname()
 	if err != nil {
-		if debugLog {
-			OboeLog(ERROR, "Unable to get hostname, AppOptics tracing disabled: %v", err)
-		}
+		agent.Log(agent.ERROR, "Unable to get hostname, AppOptics tracing disabled: %v", err)
 		reportingDisabled = true
 	}
 	cachedHostname = h

--- a/v1/ao/internal/reporter/reporter.go
+++ b/v1/ao/internal/reporter/reporter.go
@@ -5,6 +5,7 @@ package reporter
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -50,7 +51,11 @@ func (r *nullReporter) reportSpan(span SpanMessage) error             { return n
 // can be overridden via APPOPTICS_REPORTER
 func init() {
 	cacheHostname(osHostnamer{})
-	setGlobalReporter(os.Getenv("APPOPTICS_REPORTER"))
+	r := os.Getenv("APPOPTICS_REPORTER")
+	if r != "" {
+		OboeLog(INFO, fmt.Sprintf("Non-default APPOPTICS_REPORTER: %s", r))
+	}
+	setGlobalReporter(r)
 	sendInitMessage()
 }
 

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -14,8 +14,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"unicode/utf8"
-
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter/collector"
 	"golang.org/x/net/context"
@@ -134,25 +132,6 @@ func verifyServiceKey(key string) error {
 	return nil
 }
 
-// verifyAndMaskServiceKey verifies if the service key is valid. If so, it then masks the
-// middle part of the token and returns the masked service key
-func maskServiceKey(validKey string) string {
-	var sep = ":"
-	var hLen, tLen = 4, 4
-	var mask = "*"
-
-	s := strings.Split(validKey, sep)
-	tk := s[0]
-
-	if len(tk) <= hLen+tLen {
-		return validKey
-	}
-
-	tk = tk[0:4] + strings.Repeat(mask, utf8.RuneCountInString(tk)-hLen-tLen) + tk[len(tk)-4:]
-
-	return tk + sep + s[1]
-}
-
 // initializes a new GRPC reporter from scratch (called once on program startup)
 //
 // returns	GRPC reporter object
@@ -166,7 +145,6 @@ func newGRPCReporter() reporter {
 	if err := verifyServiceKey(serviceKey); err != nil {
 		return &nullReporter{}
 	}
-	agent.Log(agent.INFO, fmt.Sprintf("Non-default APPOPTICS_SERVICE_KEY[masked]: %s", maskServiceKey(serviceKey)))
 
 	// see if a hostname alias is configured
 	configuredHostname = agent.GetConfig(agent.AppOpticsHostnameAlias)

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -121,8 +121,8 @@ type grpcReporter struct {
 
 // A valid service key is something like 'service_token:service_name'.
 // The service_token should be of 64 characters long and the size of
-// service_name is larger than 0 but up to 256 characters.
-var isValidServiceKey = regexp.MustCompile(`^[a-zA-Z0-9]{64}:\S{1,256}$`).MatchString
+// service_name is larger than 0 but up to 255 characters.
+var isValidServiceKey = regexp.MustCompile(`^[a-zA-Z0-9]{64}:\S{1,255}$`).MatchString
 
 // initializes a new GRPC reporter from scratch (called once on program startup)
 //
@@ -135,7 +135,8 @@ func newGRPCReporter() reporter {
 	// service key is required, so bail out if not found
 	serviceKey := agent.GetConfig(agent.AppOpticsServiceKey)
 	if !isValidServiceKey(serviceKey) {
-		agent.Warningf("Invalid service key: %s", serviceKey)
+		agent.Warningf("Invalid service key (token:serviceName): <%s>. Reporter disabled.", serviceKey)
+		agent.Warning("Check AppOptics dashboard for your token and use a service name shorter than 256 characters.")
 		return &nullReporter{}
 	}
 

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -241,7 +241,7 @@ func grpcCreateClientConnection(cert []byte, addr string, insecureSkipVerify boo
 	certPool := x509.NewCertPool()
 
 	if ok := certPool.AppendCertsFromPEM(cert); !ok {
-		return nil, errors.New("Unable to append the certificate to pool.")
+		return nil, errors.New("unable to append the certificate to pool")
 	}
 
 	// trim port from server name used for TLS verification
@@ -409,7 +409,7 @@ func (r *grpcReporter) reportEvent(ctx *oboeContext, e *event) error {
 		return nil
 	default:
 		go atomic.AddInt64(&r.eventConnection.queueStats.numOverflowed, int64(1)) // use goroutine so this won't block on the critical path
-		return errors.New("Event message queue is full")
+		return errors.New("event message queue is full")
 	}
 }
 
@@ -851,7 +851,7 @@ func (r *grpcReporter) reportStatus(ctx *oboeContext, e *event) error {
 	case r.statusMessages <- (*e).bbuf.GetBuf():
 		return nil
 	default:
-		return errors.New("Status message queue is full")
+		return errors.New("status message queue is full")
 	}
 }
 
@@ -973,7 +973,7 @@ func (r *grpcReporter) reportSpan(span SpanMessage) error {
 	case r.spanMessages <- span:
 		return nil
 	default:
-		return errors.New("Span message queue is full")
+		return errors.New("span message queue is full")
 	}
 }
 

--- a/v1/ao/internal/reporter/reporter_grpc_test.go
+++ b/v1/ao/internal/reporter/reporter_grpc_test.go
@@ -3,6 +3,7 @@
 package reporter
 
 import (
+	"errors"
 	"net"
 	"os"
 	"path"
@@ -97,4 +98,34 @@ func (s *TestGRPCServer) Ping(context.Context, *pb.PingRequest) (*pb.MessageResu
 }
 
 func TestGrpcNewReporter(t *testing.T) {
+}
+
+func TestVerifyServiceKey(t *testing.T) {
+
+	keyPairs := map[string]error{
+		"1234567890abcdef:Go": nil,
+		"":                  errors.New("invalid service key: empty string"),
+		"abc:Go":            nil,
+		"abcd1234:Go":       nil,
+		"1234567890abcdef":  errors.New("invalid service key: no colon found or tk/service name is missing"),
+		"1234567890abcdef:": errors.New("invalid service key: no colon found or tk/service name is missing"),
+		":Go":               errors.New("invalid service key: no colon found or tk/service name is missing"),
+		"abc:123:Go":        errors.New("invalid service key: no colon found or tk/service name is missing"),
+	}
+
+	for key, err := range keyPairs {
+		assert.Equal(t, err, verifyServiceKey(key))
+	}
+}
+
+func TestMaskServiceKey(t *testing.T) {
+	keyPairs := map[string]string{
+		"1234567890abcdef:Go": "1234********cdef:Go",
+		"abc:Go":              "abc:Go",
+		"abcd1234:Go":         "abcd1234:Go",
+	}
+
+	for key, masked := range keyPairs {
+		assert.Equal(t, masked, maskServiceKey(key))
+	}
 }

--- a/v1/ao/internal/reporter/reporter_grpc_test.go
+++ b/v1/ao/internal/reporter/reporter_grpc_test.go
@@ -3,7 +3,6 @@
 package reporter
 
 import (
-	"errors"
 	"net"
 	"os"
 	"path"
@@ -100,20 +99,24 @@ func (s *TestGRPCServer) Ping(context.Context, *pb.PingRequest) (*pb.MessageResu
 func TestGrpcNewReporter(t *testing.T) {
 }
 
-func TestVerifyServiceKey(t *testing.T) {
+func TestIsValidServiceKey(t *testing.T) {
 
-	keyPairs := map[string]error{
-		"1234567890abcdef:Go": nil,
-		"":                  errors.New("invalid service key: empty string"),
-		"abc:Go":            nil,
-		"abcd1234:Go":       nil,
-		"1234567890abcdef":  errors.New("invalid service key: no colon found or the token/service name is missing"),
-		"1234567890abcdef:": errors.New("invalid service key: no colon found or the token/service name is missing"),
-		":Go":               errors.New("invalid service key: no colon found or the token/service name is missing"),
-		"abc:123:Go":        errors.New("invalid service key: no colon found or the token/service name is missing"),
+	keyPairs := map[string]bool{
+		"ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189217:Go": true,
+		"":       false,
+		"abc:Go": false,
+		"ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189217:" +
+			"Go0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" +
+			"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" +
+			"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" +
+			"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef": false,
+		"1234567890abcdef":  false,
+		"1234567890abcdef:": false,
+		":Go":               false,
+		"abc:123:Go":        false,
 	}
 
-	for key, err := range keyPairs {
-		assert.Equal(t, err, verifyServiceKey(key))
+	for key, valid := range keyPairs {
+		assert.Equal(t, valid, isValidServiceKey(key))
 	}
 }

--- a/v1/ao/internal/reporter/reporter_grpc_test.go
+++ b/v1/ao/internal/reporter/reporter_grpc_test.go
@@ -117,15 +117,3 @@ func TestVerifyServiceKey(t *testing.T) {
 		assert.Equal(t, err, verifyServiceKey(key))
 	}
 }
-
-func TestMaskServiceKey(t *testing.T) {
-	keyPairs := map[string]string{
-		"1234567890abcdef:Go": "1234********cdef:Go",
-		"abc:Go":              "abc:Go",
-		"abcd1234:Go":         "abcd1234:Go",
-	}
-
-	for key, masked := range keyPairs {
-		assert.Equal(t, masked, maskServiceKey(key))
-	}
-}

--- a/v1/ao/internal/reporter/reporter_grpc_test.go
+++ b/v1/ao/internal/reporter/reporter_grpc_test.go
@@ -107,10 +107,10 @@ func TestVerifyServiceKey(t *testing.T) {
 		"":                  errors.New("invalid service key: empty string"),
 		"abc:Go":            nil,
 		"abcd1234:Go":       nil,
-		"1234567890abcdef":  errors.New("invalid service key: no colon found or tk/service name is missing"),
-		"1234567890abcdef:": errors.New("invalid service key: no colon found or tk/service name is missing"),
-		":Go":               errors.New("invalid service key: no colon found or tk/service name is missing"),
-		"abc:123:Go":        errors.New("invalid service key: no colon found or tk/service name is missing"),
+		"1234567890abcdef":  errors.New("invalid service key: no colon found or the token/service name is missing"),
+		"1234567890abcdef:": errors.New("invalid service key: no colon found or the token/service name is missing"),
+		":Go":               errors.New("invalid service key: no colon found or the token/service name is missing"),
+		"abc:123:Go":        errors.New("invalid service key: no colon found or the token/service name is missing"),
 	}
 
 	for key, err := range keyPairs {

--- a/v1/ao/internal/reporter/reporter_test.go
+++ b/v1/ao/internal/reporter/reporter_test.go
@@ -17,6 +17,7 @@ import (
 
 	"strings"
 
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent"
 	g "github.com/appoptics/appoptics-apm-go/v1/ao/internal/graphtest"
 	pb "github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter/collector"
 	"github.com/stretchr/testify/assert"
@@ -26,7 +27,7 @@ import (
 )
 
 const (
-	serviceKey = "ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189217:Go"
+	serviceKey = "ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189217:go"
 )
 
 // this runs before init()
@@ -213,7 +214,8 @@ func assertSSLMode(t *testing.T) {
 
 func TestGRPCReporter(t *testing.T) {
 	// start test gRPC server
-	debugLevel = DEBUG
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "debug")
+	agent.Init()
 	addr := "localhost:4567"
 	grpclog.SetLogger(log.New(os.Stdout, "grpc: ", log.LstdFlags))
 	server := StartTestGRPCServer(t, addr)
@@ -223,6 +225,7 @@ func TestGRPCReporter(t *testing.T) {
 	reportingDisabled = false
 	os.Setenv("APPOPTICS_COLLECTOR", addr)
 	os.Setenv("APPOPTICS_TRUSTEDPATH", testCertFile)
+	agent.Init()
 	oldReporter := globalReporter
 	setGlobalReporter("ssl")
 
@@ -301,7 +304,8 @@ func TestInterruptedGRPCReporter(t *testing.T) {
 	}()
 
 	// start test gRPC server
-	debugLevel = INFO
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "info")
+	agent.Init()
 	addr := "localhost:4567"
 	// Open it if for verbose print of gRPC
 	//grpclog.SetLogger(log.New(os.Stdout, "grpc: ", log.LstdFlags))
@@ -312,6 +316,7 @@ func TestInterruptedGRPCReporter(t *testing.T) {
 	reportingDisabled = false
 	os.Setenv("APPOPTICS_COLLECTOR", addr)
 	os.Setenv("APPOPTICS_TRUSTEDPATH", testCertFile)
+	agent.Init()
 	oldReporter := globalReporter
 	setGlobalReporter("ssl")
 
@@ -377,8 +382,8 @@ func TestInterruptedGRPCReporter(t *testing.T) {
 
 func TestRedirect(t *testing.T) {
 	// start test gRPC server
-	debugLevel = INFO
-
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "info")
+	agent.Init()
 	addr := "localhost:4567"
 	// Open it if for verbose print of gRPC
 	//grpclog.SetLogger(log.New(os.Stdout, "grpc: ", log.LstdFlags))
@@ -389,6 +394,7 @@ func TestRedirect(t *testing.T) {
 	reportingDisabled = false
 	os.Setenv("APPOPTICS_COLLECTOR", addr)
 	os.Setenv("APPOPTICS_TRUSTEDPATH", testCertFile)
+	agent.Init()
 	oldReporter := globalReporter
 	setGlobalReporter("ssl")
 

--- a/v1/ao/internal/reporter/reporter_test.go
+++ b/v1/ao/internal/reporter/reporter_test.go
@@ -34,6 +34,8 @@ const (
 var _ = func() (_ struct{}) {
 	os.Setenv("APPOPTICS_SERVICE_KEY", serviceKey)
 	os.Setenv("APPOPTICS_REPORTER", "none")
+	// Call agent.Init() after changing any environment variables for testing.
+	agent.Init()
 	return
 }()
 

--- a/v1/ao/internal/reporter/reporter_udp.go
+++ b/v1/ao/internal/reporter/reporter_udp.go
@@ -33,7 +33,7 @@ func udpNewReporter() reporter {
 		conn, err = net.DialUDP("udp4", nil, serverAddr)
 	}
 	if err != nil {
-		agent.Error("AppOptics failed to initialize UDP reporter: %v", err)
+		agent.Errorf("AppOptics failed to initialize UDP reporter: %v", err)
 		return &nullReporter{}
 	}
 

--- a/v1/ao/internal/reporter/reporter_udp.go
+++ b/v1/ao/internal/reporter/reporter_udp.go
@@ -3,7 +3,6 @@
 package reporter
 
 import (
-	"fmt"
 	"net"
 
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent"
@@ -34,7 +33,7 @@ func udpNewReporter() reporter {
 		conn, err = net.DialUDP("udp4", nil, serverAddr)
 	}
 	if err != nil {
-		agent.Log(agent.ERROR, fmt.Sprintf("AppOptics failed to initialize UDP reporter: %v", err))
+		agent.Error("AppOptics failed to initialize UDP reporter: %v", err)
 		return &nullReporter{}
 	}
 

--- a/v1/ao/internal/reporter/reporter_udp.go
+++ b/v1/ao/internal/reporter/reporter_udp.go
@@ -5,7 +5,8 @@ package reporter
 import (
 	"fmt"
 	"net"
-	"os"
+
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent"
 )
 
 const (
@@ -23,11 +24,9 @@ func udpNewReporter() reporter {
 	}
 
 	// collector address override
-	udpAddress := os.Getenv("APPOPTICS_COLLECTOR_UDP")
+	udpAddress := agent.GetConfig(agent.AppOpticsCollectorUDP)
 	if udpAddress == "" {
 		udpAddress = udpAddrDefault
-	} else {
-		OboeLog(INFO, fmt.Sprintf("Non-default APPOPTICS_COLLECTOR_UDP: %s", udpAddress))
 	}
 
 	serverAddr, err := net.ResolveUDPAddr("udp4", udpAddress)
@@ -35,7 +34,7 @@ func udpNewReporter() reporter {
 		conn, err = net.DialUDP("udp4", nil, serverAddr)
 	}
 	if err != nil {
-		OboeLog(ERROR, fmt.Sprintf("AppOptics failed to initialize UDP reporter: %v", err))
+		agent.Log(agent.ERROR, fmt.Sprintf("AppOptics failed to initialize UDP reporter: %v", err))
 		return &nullReporter{}
 	}
 

--- a/v1/ao/internal/reporter/reporter_udp.go
+++ b/v1/ao/internal/reporter/reporter_udp.go
@@ -26,6 +26,8 @@ func udpNewReporter() reporter {
 	udpAddress := os.Getenv("APPOPTICS_COLLECTOR_UDP")
 	if udpAddress == "" {
 		udpAddress = udpAddrDefault
+	} else {
+		OboeLog(INFO, fmt.Sprintf("Non-default APPOPTICS_COLLECTOR_UDP: %s", udpAddress))
 	}
 
 	serverAddr, err := net.ResolveUDPAddr("udp4", udpAddress)

--- a/v1/ao/internal/reporter/test_reporter.go
+++ b/v1/ao/internal/reporter/test_reporter.go
@@ -4,6 +4,7 @@ package reporter
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"sync"
 	"sync/atomic"
@@ -149,6 +150,7 @@ func (r *TestReporter) Close(numBufs int) {
 }
 
 func (r *TestReporter) report(ctx *oboeContext, e *event) error {
+	fmt.Println("Before TestReporter............")
 	if err := prepareEvent(ctx, e); err != nil {
 		// don't continue if preparation failed
 		return err
@@ -159,6 +161,7 @@ func (r *TestReporter) report(ctx *oboeContext, e *event) error {
 		(r.ErrorEvents != nil && r.ErrorEvents[(int(r.eventCount)-1)]) { // error certain specified events
 		return errors.New("TestReporter error")
 	}
+	fmt.Println("In TestReporter, sending ............", e.bbuf.GetBuf())
 	r.eventChan <- (*e).bbuf.GetBuf() // a send to a closed channel panics.
 	return nil
 }

--- a/v1/ao/internal/reporter/test_reporter.go
+++ b/v1/ao/internal/reporter/test_reporter.go
@@ -4,7 +4,6 @@ package reporter
 
 import (
 	"errors"
-	"fmt"
 	"log"
 	"sync"
 	"sync/atomic"
@@ -150,7 +149,6 @@ func (r *TestReporter) Close(numBufs int) {
 }
 
 func (r *TestReporter) report(ctx *oboeContext, e *event) error {
-	fmt.Println("Before TestReporter............")
 	if err := prepareEvent(ctx, e); err != nil {
 		// don't continue if preparation failed
 		return err
@@ -161,7 +159,6 @@ func (r *TestReporter) report(ctx *oboeContext, e *event) error {
 		(r.ErrorEvents != nil && r.ErrorEvents[(int(r.eventCount)-1)]) { // error certain specified events
 		return errors.New("TestReporter error")
 	}
-	fmt.Println("In TestReporter, sending ............", e.bbuf.GetBuf())
 	r.eventChan <- (*e).bbuf.GetBuf() // a send to a closed channel panics.
 	return nil
 }

--- a/v1/ao/internal/reporter/utils.go
+++ b/v1/ao/internal/reporter/utils.go
@@ -7,10 +7,8 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"log"
 	"math"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -28,58 +26,6 @@ func printBson(message []byte) {
 }
 
 ///////////////////////
-
-// DebugLevel is a type that defines the log level.
-type DebugLevel uint8
-
-// log levels
-const (
-	DEBUG DebugLevel = iota
-	INFO
-	WARNING
-	ERROR
-)
-
-var dbgLevels = []string{
-	DEBUG:   "DEBUG",
-	INFO:    "INFO",
-	WARNING: "WARN",
-	ERROR:   "ERROR",
-}
-
-var debugLevel = ERROR
-var debugLog = true
-
-// ElemOffset is a simple helper function to check if a slice contains a specific element
-func ElemOffset(s []string, e string) int {
-	for idx, i := range s {
-		if e == i {
-			return idx
-		}
-	}
-	return -1
-}
-
-// OboeLog print logs based on the debug level.
-func OboeLog(level DebugLevel, msg string, args ...interface{}) {
-	if !debugLog || level < debugLevel { // debugLog is always true for now.
-		return
-	}
-	var p string
-	pc, f, l, ok := runtime.Caller(1)
-	if ok {
-		path := strings.Split(runtime.FuncForPC(pc).Name(), ".")
-		name := path[len(path)-1]
-		p = fmt.Sprintf("%s %s#%d %s(): ", dbgLevels[level], filepath.Base(f), l, name)
-	} else {
-		p = fmt.Sprintf("%s %s#%s %s(): ", dbgLevels[level], "na", "na", "na")
-	}
-	if len(args) == 0 {
-		log.Printf("%s%s", p, msg)
-	} else {
-		log.Printf("%s%s %v", p, msg, args)
-	}
-}
 
 // getLineByKeword reads a file, searches for the keyword and returns the matched line.
 // It returns empty string "" if no match found or failed to open the path.


### PR DESCRIPTION
What has been done:
1. Print all non-default configuration values in default level
2. Mask the service token while printing it
3. Refactored the code of configuration initialization and printing to avoid boilerplate (e.g., print non-default environment variable values everywhere). Now all the configurations are managed in a standalone package `agent`. Other packages can call the API provided by this package to get the current value of a specific configuration.
4. Changed the default print level from ERROR to WARN -- This is TBD. I think ERROR is too high as a default level, and it looks a bit weird to print the non-default configurations in ERROR level. However, it needs further discussion as the change breaks the backward-compatibility.