### PR TITLE
AO-8850: reset transaction names map in every metrics reporting cycle

### DIFF
--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -350,6 +350,9 @@ func NewContext(layer, mdStr string, reportEntry bool, cb func() map[string]inte
 			}
 			kvs["SampleRate"] = rate
 			kvs["SampleSource"] = source
+			if _, ok = ctx.(*oboeContext); !ok {
+				return &nullContext{}, false
+			}
 			if err := ctx.(*oboeContext).reportEventMap(LabelEntry, layer, addCtxEdge, kvs); err != nil {
 				return &nullContext{}, false
 			}

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -86,7 +86,8 @@ func sendInitMessage() {
 		// create new event from context
 		e, err := c.newEvent("single", "go")
 		if err != nil {
-			agent.Error("Error while creating the init message")
+			agent.Error("Error while creating the init message: %v", err)
+			return
 		}
 
 		e.AddKV("__Init", 1)

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -809,13 +809,11 @@ func (r *grpcReporter) updateSettings(settings *collector.SettingsResult) {
 		r.collectMetricIntervalLock.Unlock()
 
 		// update MaxTransactions
-		metricsHTTPMeasurements.transactionNameMaxLock.Lock()
+		capacity := metricsTransactionsMaxDefault
 		if max, ok := s.Arguments["MaxTransactions"]; ok {
-			metricsHTTPMeasurements.transactionNameMax = int(binary.LittleEndian.Uint32(max))
-		} else {
-			metricsHTTPMeasurements.transactionNameMax = metricsTransactionsMaxDefault
+			capacity = int(binary.LittleEndian.Uint32(max))
 		}
-		metricsHTTPMeasurements.transactionNameMaxLock.Unlock()
+		mTransMap.SetCap(capacity)
 	}
 }
 

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -175,6 +175,14 @@ func (t *aoTrace) reportExit() {
 		t.lock.Lock()
 		defer t.lock.Unlock()
 
+		// The trace may have been ended by another goroutine (?) after the last
+		// check (t.ok()) but before we acquire the lock. So a double check is
+		// worthwhile.
+		// However, we need to check t.ended directly as t.ok() will cause deadlock.
+		if t.ended {
+			return
+		}
+
 		// if this is an HTTP trace, record a new span
 		if !t.httpSpan.start.IsZero() {
 			t.httpSpan.span.Duration = time.Now().Sub(t.httpSpan.start)


### PR DESCRIPTION
Jira: https://swicloud.atlassian.net/browse/AO-8850

1. Refactored the transaction names map and reset it after reporting the metrics
2. Some minor fixes.