### PR TITLE
AO-8322: improvement on error handlings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.test
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,19 +22,19 @@ install:
 script:
   - cd $GOPATH/src/github.com/appoptics/appoptics-apm-go/v1/ao
   - go build -v github.com/appoptics/appoptics-apm-go/v1/ao github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent
-  - go test -v -covermode=atomic -coverprofile=cov.out -coverpkg github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent,github.com/appoptics/appoptics-apm-go/v1/ao
-  - go test -v -tags disable_tracing -covermode=atomic -coverprofile=covao.out -coverpkg github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent,github.com/appoptics/appoptics-apm-go/v1/ao
+  - go test -v -race -covermode=atomic -coverprofile=cov.out -coverpkg github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent,github.com/appoptics/appoptics-apm-go/v1/ao
+  - go test -v -race -tags disable_tracing -covermode=atomic -coverprofile=covao.out -coverpkg github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent,github.com/appoptics/appoptics-apm-go/v1/ao
   - pushd internal/reporter/
-  - go test -v -covermode=atomic -coverprofile=cov.out
-  - go test -v -tags disable_tracing -covermode=atomic -coverprofile=covao.out
+  - go test -v -race -covermode=atomic -coverprofile=cov.out
+  - go test -v -race -tags disable_tracing -covermode=atomic -coverprofile=covao.out
   - popd
   - pushd internal/agent/
-  - go test -v -covermode=atomic -coverprofile=cov.out
-  - go test -v -tags disable_tracing -covermode=atomic -coverprofile=covao.out
+  - go test -v -race -covermode=atomic -coverprofile=cov.out
+  - go test -v -race -tags disable_tracing -covermode=atomic -coverprofile=covao.out
   - popd
   - pushd opentracing
-  - go test -v -covermode=atomic -coverprofile=cov.out -coverpkg github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent,github.com/appoptics/appoptics-apm-go/v1/ao/opentracing,github.com/appoptics/appoptics-apm-go/v1/ao
-  - go test -v -tags disable_tracing -covermode=atomic -coverprofile=covao.out -coverpkg github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent,github.com/appoptics/appoptics-apm-go/v1/ao/opentracing,github.com/appoptics/appoptics-apm-go/v1/ao
+  - go test -v -race -covermode=atomic -coverprofile=cov.out -coverpkg github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent,github.com/appoptics/appoptics-apm-go/v1/ao/opentracing,github.com/appoptics/appoptics-apm-go/v1/ao
+  - go test -v -race -tags disable_tracing -covermode=atomic -coverprofile=covao.out -coverpkg github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent,github.com/appoptics/appoptics-apm-go/v1/ao/opentracing,github.com/appoptics/appoptics-apm-go/v1/ao
   - popd
   - gocovmerge cov.out covao.out internal/reporter/cov.out internal/reporter/covao.out internal/agent/cov.out internal/agent/covao.out opentracing/cov.out opentracing/covao.out > coverage.txt
 

--- a/v1/ao/cov.sh
+++ b/v1/ao/cov.sh
@@ -3,22 +3,22 @@ set -e
 
 COVERPKG="github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent,github.com/appoptics/appoptics-apm-go/v1/ao,github.com/appoptics/appoptics-apm-go/v1/ao/opentracing"
 export APPOPTICS_DEBUG_LEVEL=1
-go test -v -race -covermode=count -coverprofile=cov.out -coverpkg $COVERPKG
-go test -v -race -tags disable_tracing -covermode=count -coverprofile=covao.out -coverpkg $COVERPKG
+go test -v -race -covermode=atomic -coverprofile=cov.out -coverpkg $COVERPKG
+go test -v -race -tags disable_tracing -covermode=atomic -coverprofile=covao.out -coverpkg $COVERPKG
 
 pushd internal/reporter/
-go test -v -race -covermode=count -coverprofile=cov.out
-go test -v -race -tags disable_tracing -covermode=count -coverprofile=covao.out
+go test -v -race -covermode=atomic -coverprofile=cov.out
+go test -v -race -tags disable_tracing -covermode=atomic -coverprofile=covao.out
 popd
 
 pushd internal/agent/
-go test -v -race -covermode=count -coverprofile=cov.out
-go test -v -race -tags disable_tracing -covermode=count -coverprofile=covao.out
+go test -v -race -covermode=atomic -coverprofile=cov.out
+go test -v -race -tags disable_tracing -covermode=atomic -coverprofile=covao.out
 popd
 
 pushd opentracing
-go test -v -race -covermode=count -coverprofile=cov.out
-go test -v -race -tags disable_tracing -covermode=count -coverprofile=covao.out
+go test -v -race -covermode=atomic -coverprofile=cov.out
+go test -v -race -tags disable_tracing -covermode=atomic -coverprofile=covao.out
 popd
 
 gocovmerge cov.out covao.out internal/reporter/cov.out internal/reporter/covao.out internal/agent/cov.out internal/agent/covao.out opentracing/cov.out opentracing/covao.out > covmerge.out

--- a/v1/ao/cov.sh
+++ b/v1/ao/cov.sh
@@ -3,22 +3,22 @@ set -e
 
 COVERPKG="github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter,github.com/appoptics/appoptics-apm-go/v1/ao/internal/agent,github.com/appoptics/appoptics-apm-go/v1/ao,github.com/appoptics/appoptics-apm-go/v1/ao/opentracing"
 export APPOPTICS_DEBUG_LEVEL=1
-go test -v -covermode=count -coverprofile=cov.out -coverpkg $COVERPKG
-go test -v -tags disable_tracing -covermode=count -coverprofile=covao.out -coverpkg $COVERPKG
+go test -v -race -covermode=count -coverprofile=cov.out -coverpkg $COVERPKG
+go test -v -race -tags disable_tracing -covermode=count -coverprofile=covao.out -coverpkg $COVERPKG
 
 pushd internal/reporter/
-go test -v -covermode=count -coverprofile=cov.out
-go test -v -tags disable_tracing -covermode=count -coverprofile=covao.out
+go test -v -race -covermode=count -coverprofile=cov.out
+go test -v -race -tags disable_tracing -covermode=count -coverprofile=covao.out
 popd
 
 pushd internal/agent/
-go test -v -covermode=count -coverprofile=cov.out
-go test -v -tags disable_tracing -covermode=count -coverprofile=covao.out
+go test -v -race -covermode=count -coverprofile=cov.out
+go test -v -race -tags disable_tracing -covermode=count -coverprofile=covao.out
 popd
 
 pushd opentracing
-go test -v -covermode=count -coverprofile=cov.out
-go test -v -tags disable_tracing -covermode=count -coverprofile=covao.out
+go test -v -race -covermode=count -coverprofile=cov.out
+go test -v -race -tags disable_tracing -covermode=count -coverprofile=covao.out
 popd
 
 gocovmerge cov.out covao.out internal/reporter/cov.out internal/reporter/covao.out internal/agent/cov.out internal/agent/covao.out opentracing/cov.out opentracing/covao.out > covmerge.out

--- a/v1/ao/internal/agent/config_test.go
+++ b/v1/ao/internal/agent/config_test.go
@@ -26,3 +26,25 @@ func TestGetConfig(t *testing.T) {
 	Init()
 	assert.Equal(t, "collector.appoptics.com:443", GetConfig(ConfName("APPOPTICS_COLLECTOR")))
 }
+
+func TestIsValidServiceKey(t *testing.T) {
+
+	keyPairs := map[string]bool{
+		"ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189217:Go": true,
+		"":       false,
+		"abc:Go": false,
+		"ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189217:" +
+			"Go0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" +
+			"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" +
+			"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" +
+			"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef": false,
+		"1234567890abcdef":  false,
+		"1234567890abcdef:": false,
+		":Go":               false,
+		"abc:123:Go":        false,
+	}
+
+	for key, valid := range keyPairs {
+		assert.Equal(t, valid, IsValidServiceKey(key))
+	}
+}

--- a/v1/ao/internal/reporter/reporter.go
+++ b/v1/ao/internal/reporter/reporter.go
@@ -20,6 +20,10 @@ type reporter interface {
 	reportStatus(ctx *oboeContext, e *event) error
 	// called when a Span message should be reported
 	reportSpan(span SpanMessage) error
+	// Shutdown closes the reporter.
+	Shutdown() error
+	// Closed returns if the reporter is already closed.
+	Closed() bool
 }
 
 // currently used reporter
@@ -46,6 +50,8 @@ func NeedPrependDomain() bool { return prependDomainForTransactionName }
 func (r *nullReporter) reportEvent(ctx *oboeContext, e *event) error  { return nil }
 func (r *nullReporter) reportStatus(ctx *oboeContext, e *event) error { return nil }
 func (r *nullReporter) reportSpan(span SpanMessage) error             { return nil }
+func (r *nullReporter) Shutdown() error                               { return nil }
+func (r *nullReporter) Closed() bool                                  { return true }
 
 // init() is called only once on program startup. Here we create the reporter
 // that will be used throughout the runtime of the app. Default is 'ssl' but

--- a/v1/ao/internal/reporter/reporter.go
+++ b/v1/ao/internal/reporter/reporter.go
@@ -63,6 +63,11 @@ func init() {
 }
 
 func setGlobalReporter(reporterType string) {
+	// Close the previous reporter
+	if globalReporter != nil {
+		globalReporter.Shutdown()
+	}
+
 	switch strings.ToLower(reporterType) {
 	case "ssl":
 		fallthrough // using fallthrough since the SSL reporter (GRPC) is our default reporter

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -62,6 +62,7 @@ ftgwcxyEq5SkiR+6BCwdzAMqADV37TzXDHLjwSrMIrgLV5xZM20Kk6chxI5QAr/f
 	grpcRetryDelayMax                       = 60  // max connection/send retry delay in seconds
 	grpcRedirectMax                         = 20  // max allowed collector redirects
 	grpcRetryLogThreshold                   = 10  // log prints after this number of retries (about 56.7s)
+	grpcMaxRetries                          = 20  // The message will be dropped after this number of retries
 )
 
 // ID of first goroutine that attempts to reconnect a given GRPC client (eventConnection
@@ -559,6 +560,9 @@ func (r *grpcReporter) eventRetrySender(
 				} else {
 					agent.Debugf("(%v) Error calling PostEvents(): %v", failsNum, err)
 				}
+				if failsNum >= grpcMaxRetries {
+					break
+				}
 			} else {
 				if failsPrinted {
 					agent.Warning("Error recovered in PostEvents()")
@@ -717,6 +721,9 @@ func (r *grpcReporter) sendMetrics(ready chan bool) {
 			} else {
 				agent.Debugf("(%v) Error calling PostMetrics(): %v", failsNum, err)
 			}
+			if failsNum >= grpcMaxRetries {
+				break
+			}
 		} else {
 			if failsPrinted {
 				agent.Warning("Error recovered in PostMetrics()")
@@ -809,6 +816,9 @@ func (r *grpcReporter) getSettings(ready chan bool) {
 				failsPrinted = true
 			} else {
 				agent.Debugf("(%v) Error calling GetSettings(): %v", failsNum, err)
+			}
+			if failsNum >= grpcMaxRetries {
+				break
 			}
 		} else {
 			if failsPrinted {
@@ -976,6 +986,9 @@ func (r *grpcReporter) statusSender() {
 					failsPrinted = true
 				} else {
 					agent.Debugf("(%v) Error calling PostStatus(): %v", failsNum, err)
+				}
+				if failsNum >= grpcMaxRetries {
+					break
 				}
 			} else {
 				if failsPrinted {

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -583,8 +583,6 @@ func (r *grpcReporter) eventRetrySender(
 		failsNum := 0
 		// Number of retries, including gRPC errors and collector errors
 		retriesNum := 0
-		// The flag to turn on/off high level logging for fails
-		failsPrinted := false
 
 		for !resultOK {
 			// Fail-fast in case the reporter has been closed, avoid retrying in this case.
@@ -605,19 +603,17 @@ func (r *grpcReporter) eventRetrySender(
 			if err != nil {
 				// gRPC handles the reconnection automatically.
 				failsNum++
-				if failsNum > grpcRetryLogThreshold && !failsPrinted {
+				if failsNum == grpcRetryLogThreshold {
 					agent.Warningf("Error calling PostEvents(): %v", err)
-					failsPrinted = true
 				} else {
 					agent.Debugf("(%v) Error calling PostEvents(): %v", failsNum, err)
 				}
 			} else {
-				if failsPrinted {
+				if failsNum >= grpcRetryLogThreshold {
 					agent.Warning("Error recovered in PostEvents()")
-					// Reset the flags here as there might be extra retries even the transport layer is recovered.
-					failsPrinted = false
-					failsNum = 0
 				}
+				failsNum = 0
+
 				// server responded, check the result code and perform actions accordingly
 				switch result := response.GetResult(); result {
 				case collector.ResultCode_OK:
@@ -748,8 +744,6 @@ func (r *grpcReporter) sendMetrics(ready chan bool) {
 	failsNum := 0
 	// Number of retries, including gRPC errors and collector errors
 	retriesNum := 0
-	// The flag to turn on/off high level logging for fails
-	failsPrinted := false
 
 	// TODO: boilerplate code refactor as events/metrics/settings share similar processes.
 	for !resultOK {
@@ -771,19 +765,17 @@ func (r *grpcReporter) sendMetrics(ready chan bool) {
 		if err != nil {
 			// gRPC handles the reconnection automatically.
 			failsNum++
-			if failsNum > grpcRetryLogThreshold && !failsPrinted {
+			if failsNum == grpcRetryLogThreshold {
 				agent.Warningf("Error calling PostMetrics(): %v", err)
-				failsPrinted = true
 			} else {
 				agent.Debugf("(%v) Error calling PostMetrics(): %v", failsNum, err)
 			}
 		} else {
-			if failsPrinted {
+			if failsNum >= grpcRetryLogThreshold {
 				agent.Warning("Error recovered in PostMetrics()")
-				// Reset the flags here as there might be extra retries even the transport layer is recovered.
-				failsPrinted = false
-				failsNum = 0
 			}
+			failsNum = 0
+
 			// server responded, check the result code and perform actions accordingly
 			switch result := response.GetResult(); result {
 			case collector.ResultCode_OK:
@@ -850,8 +842,6 @@ func (r *grpcReporter) getSettings(ready chan bool) {
 	failsNum := 0
 	// Number of retries, including gRPC errors and collector errors
 	retriesNum := 0
-	// The flag to turn on/off high level logging for fails
-	failsPrinted := false
 
 	for !resultOK {
 		// Fail-fast in case the reporter has been closed, avoid retrying in this case.
@@ -872,19 +862,17 @@ func (r *grpcReporter) getSettings(ready chan bool) {
 		if err != nil {
 			// gRPC handles the reconnection automatically.
 			failsNum++
-			if failsNum > grpcRetryLogThreshold && !failsPrinted {
+			if failsNum == grpcRetryLogThreshold {
 				agent.Warningf("Error calling GetSettings(): %v", err)
-				failsPrinted = true
 			} else {
 				agent.Debugf("(%v) Error calling GetSettings(): %v", failsNum, err)
 			}
 		} else {
-			if failsPrinted {
+			if failsNum >= grpcRetryLogThreshold {
 				agent.Warning("Error recovered in GetSettings()")
-				// Reset the flags here as there might be extra retries even the transport layer is recovered.
-				failsPrinted = false
-				failsNum = 0
 			}
+			failsNum = 0
+
 			// server responded, check the result code and perform actions accordingly
 			switch result := response.GetResult(); result {
 			case collector.ResultCode_OK:
@@ -1028,8 +1016,6 @@ func (r *grpcReporter) statusSender() {
 		failsNum := 0
 		// Number of retries, including gRPC errors and collector errors
 		retriesNum := 0
-		// The flag to turn on/off high level logging for fails
-		failsPrinted := false
 
 		for !resultOK {
 			// Fail-fast in case the reporter has been closed, avoid retrying in this case.
@@ -1050,19 +1036,17 @@ func (r *grpcReporter) statusSender() {
 			if err != nil {
 				// gRPC handles the reconnection automatically.
 				failsNum++
-				if failsNum > grpcRetryLogThreshold && !failsPrinted {
+				if failsNum == grpcRetryLogThreshold {
 					agent.Warningf("Error calling PostStatus(): %v", err)
-					failsPrinted = true
 				} else {
 					agent.Debugf("(%v) Error calling PostStatus(): %v", failsNum, err)
 				}
 			} else {
-				if failsPrinted {
+				if failsNum >= grpcRetryLogThreshold {
 					agent.Warning("Error recovered in PostStatus()")
-					// Reset the flags here as there might be extra retries even the transport layer is recovered.
-					failsPrinted = false
-					failsNum = 0
 				}
+				failsNum = 0
+
 				// server responded, check the result code and perform actions accordingly
 				switch result := response.GetResult(); result {
 				case collector.ResultCode_OK:
@@ -1100,7 +1084,6 @@ func (r *grpcReporter) statusSender() {
 			}
 		}
 	}
-	agent.Warning("statusSender goroutine exiting.")
 }
 
 // ========================= Span Message Handling =============================

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -458,6 +458,9 @@ func (r *grpcReporter) setRetryDelay(oldDelay int, retryNum *int) (int, error) {
 //
 // returns	error if something goes wrong during preparation or if channel is full
 func (r *grpcReporter) reportEvent(ctx *oboeContext, e *event) error {
+	if r.Closed() {
+		return ErrReporterIsClosed
+	}
 	if err := prepareEvent(ctx, e); err != nil {
 		// don't continue if preparation failed
 		return err
@@ -964,6 +967,9 @@ func (r *grpcReporter) checkSettingsTimeout(ready chan bool) {
 //
 // returns	error if something goes wrong during preparation or if channel is full
 func (r *grpcReporter) reportStatus(ctx *oboeContext, e *event) error {
+	if r.Closed() {
+		return ErrReporterIsClosed
+	}
 	if err := prepareEvent(ctx, e); err != nil {
 		// don't continue if preparation failed
 		return err
@@ -1105,6 +1111,9 @@ func (r *grpcReporter) statusSender() {
 //
 // returns	error if channel is full
 func (r *grpcReporter) reportSpan(span SpanMessage) error {
+	if r.Closed() {
+		return ErrReporterIsClosed
+	}
 	select {
 	case r.spanMessages <- span:
 		return nil

--- a/v1/ao/internal/reporter/reporter_test.go
+++ b/v1/ao/internal/reporter/reporter_test.go
@@ -384,11 +384,11 @@ func TestInterruptedGRPCReporter(t *testing.T) {
 
 func TestRedirect(t *testing.T) {
 	// start test gRPC server
-	os.Setenv("APPOPTICS_DEBUG_LEVEL", "info")
+	os.Setenv("APPOPTICS_DEBUG_LEVEL", "debug")
 	agent.Init()
 	addr := "localhost:4567"
 	// Open it if for verbose print of gRPC
-	//grpclog.SetLogger(log.New(os.Stdout, "grpc: ", log.LstdFlags))
+	grpclog.SetLogger(log.New(os.Stdout, "grpc: ", log.LstdFlags))
 	server := StartTestGRPCServer(t, addr)
 	time.Sleep(100 * time.Millisecond)
 
@@ -426,9 +426,8 @@ func TestRedirect(t *testing.T) {
 	addr2 := "localhost:4568"
 	server = StartTestGRPCServer(t, addr2)
 	time.Sleep(time.Second * 10)
-
 	// Call redirect directly
-	r.redirect(r.eventConnection, addr2)
+	r.redirectTo(r.eventConnection, addr2)
 
 	for i := 11; i <= 20; i++ {
 		ctx := newTestContext(t)

--- a/v1/ao/internal/reporter/reporter_test.go
+++ b/v1/ao/internal/reporter/reporter_test.go
@@ -24,7 +24,6 @@ import (
 	pb "github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter/collector"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/grpclog"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -221,7 +220,6 @@ func TestGRPCReporter(t *testing.T) {
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "debug")
 	agent.Init()
 	addr := "localhost:4567"
-	grpclog.SetLogger(log.New(os.Stdout, "grpc: ", log.LstdFlags))
 	server := StartTestGRPCServer(t, addr)
 	time.Sleep(100 * time.Millisecond)
 
@@ -387,8 +385,6 @@ func TestRedirect(t *testing.T) {
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "debug")
 	agent.Init()
 	addr := "localhost:4567"
-	// Open it if for verbose print of gRPC
-	grpclog.SetLogger(log.New(os.Stdout, "grpc: ", log.LstdFlags))
 	server := StartTestGRPCServer(t, addr)
 	time.Sleep(100 * time.Millisecond)
 

--- a/v1/ao/internal/reporter/reporter_udp.go
+++ b/v1/ao/internal/reporter/reporter_udp.go
@@ -55,6 +55,17 @@ func (r *udpReporter) report(ctx *oboeContext, e *event) error {
 	return err
 }
 
+// Shutdown closes the UDP reporter TODO: not supported
+func (r *udpReporter) Shutdown() error {
+	// return r.conn.Close()
+	return nil
+}
+
+// Closed returns if the reporter is closed or not TODO: not supported
+func (r *udpReporter) Closed() bool {
+	return false
+}
+
 func (r *udpReporter) reportEvent(ctx *oboeContext, e *event) error {
 	return r.report(ctx, e)
 }

--- a/v1/ao/internal/reporter/test_reporter.go
+++ b/v1/ao/internal/reporter/test_reporter.go
@@ -148,6 +148,17 @@ func (r *TestReporter) Close(numBufs int) {
 	}
 }
 
+// Shutdown closes the Test reporter TODO: not supported
+func (r *TestReporter) Shutdown() error {
+	// return r.conn.Close()
+	return errors.New("shutdown is not supported by TestReporter")
+}
+
+// Closed returns if the reporter is closed or not TODO: not supported
+func (r *TestReporter) Closed() bool {
+	return false
+}
+
 func (r *TestReporter) report(ctx *oboeContext, e *event) error {
 	if err := prepareEvent(ctx, e); err != nil {
 		// don't continue if preparation failed

--- a/v1/ao/internal/reporter/utils.go
+++ b/v1/ao/internal/reporter/utils.go
@@ -17,15 +17,12 @@ import (
 )
 
 // for testing only
-
 func printBson(message []byte) {
 	m := make(map[string]interface{})
 	bson.Unmarshal(message, m)
 	b, _ := json.MarshalIndent(m, "", "  ")
 	fmt.Println(time.Now().Format("15:04:05"), string(b))
 }
-
-///////////////////////
 
 // getLineByKeword reads a file, searches for the keyword and returns the matched line.
 // It returns empty string "" if no match found or failed to open the path.

--- a/v1/ao/internal/reporter/utils.go
+++ b/v1/ao/internal/reporter/utils.go
@@ -16,7 +16,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
-// for testing only
+// printBson prints the BSON message. It's not concurrent-safe and is for testing only
 func printBson(message []byte) {
 	m := make(map[string]interface{})
 	bson.Unmarshal(message, m)


### PR DESCRIPTION
See: https://swicloud.atlassian.net/browse/AO-8322
1. Tear down the reporter when INVALID_API_KEY is received. (so a few checks against the r.done channel)
2. Short-circuit events reporting in case of closed reporter.
3. Replaced reconnect AUTHORITY with a lock as there is a data race.
4. Use atomic for all operations to queue stats.
5. Fixed some data race issues.
6. Other minor improvements