### PR TITLE
add explanation of Trace and Span relationship

### DIFF
--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -10,8 +10,10 @@ import (
 	"golang.org/x/net/context"
 )
 
-// Trace represents a distributed trace for this request that reports
-// events to AppOptics.
+// Trace represents the root span of a distributed trace for this request that reports
+// events to AppOptics. The Trace interface extends the Span interface with additional
+// methods that can be used to help categorize a service's inbound requests on the
+// AppOptics service dashboard.
 type Trace interface {
 	// Inherited from the Span interface
 	//  BeginSpan(spanName string, args ...interface{}) Span


### PR DESCRIPTION
Talking to @seubert this relationship was confusing at first, so I added an extra sentence to the godoc to explain that Trace is a root Span with additional methods for helping to categorize inbound requests.