### PR TITLE
Check for lowercase header name as well

### DIFF
--- a/v1/contrib/grpc/interceptors.go
+++ b/v1/contrib/grpc/interceptors.go
@@ -25,11 +25,13 @@ func tracingContext(ctx context.Context, serverName string, methodName string, s
 	xtID := ""
 	md, ok := metadata.FromIncomingContext(ctx)
 	if ok {
-		xt, ok := md[ao.HTTPHeaderName]
-		if ok {
+		if xt, ok := md[ao.HTTPHeaderName]; ok {
+			xtID = xt[0]
+		} else if xt, ok = md[strings.ToLower(ao.HTTPHeaderName)]; ok {
 			xtID = xt[0]
 		}
 	}
+
 
 	t := ao.NewTraceFromID(serverName, xtID, func() ao.KVMap {
 		return ao.KVMap{


### PR DESCRIPTION
My current setup using the client interceptor and server interceptor is resulting in the header being downcased when the server interceptor retrieves the metadata. I'm not sure what is causing this, but I think we should be checking for lowercase anyway unless there's something I don't know about case sensitive headers here.

Also, not sure that's the ideal way to check for both keys.