### PR TITLE
AO-9415: Error spec audit

### DIFF
--- a/v1/ao/layer.go
+++ b/v1/ao/layer.go
@@ -202,16 +202,19 @@ func (s *span) GetTransactionName() string {
 func (s *span) Error(class, msg string) {
 	if s.ok() {
 		s.aoCtx.ReportEvent(reporter.LabelError, s.layerName(),
-			"ErrorClass", class, "ErrorMsg", msg, "Backtrace", debug.Stack())
+			"Spec", "error",
+			"ErrorClass", class,
+			"ErrorMsg", msg,
+			"Backtrace", string(debug.Stack()))
 	}
 }
 
 // Err reports the provided error type
 func (s *span) Err(err error) {
-	if s.ok() && err != nil {
-		s.aoCtx.ReportEvent(reporter.LabelError, s.layerName(),
-			"ErrorClass", "error", "ErrorMsg", err.Error(), "Backtrace", debug.Stack())
+	if err == nil {
+		return
 	}
+	s.Error("error", err.Error())
 }
 
 // span satisfies the Extent interface and consolidates common reporting routines used by

--- a/v1/ao/layer_test.go
+++ b/v1/ao/layer_test.go
@@ -1,0 +1,41 @@
+package ao
+
+import (
+	"testing"
+
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/mgo.v2/bson"
+)
+
+func TestErrorSpec(t *testing.T) {
+	r := reporter.SetTestReporter()
+
+	tr := NewTrace("test")
+	tr.Error("testClass", "testMsg")
+	tr.End()
+
+	r.Close(3)
+
+	var foundErrEvt = false
+	for _, evt := range r.EventBufs {
+		m := make(map[string]interface{})
+		bson.Unmarshal(evt, m)
+		if m["Label"] != reporter.LabelError {
+			continue
+		}
+		foundErrEvt = true
+		// check error spec
+		assert.Equal(t, reporter.LabelError, m["Label"])
+		assert.Equal(t, "test", m["Layer"])
+		assert.Equal(t, "error", m["Spec"])
+		assert.Equal(t, "testMsg", m["ErrorMsg"])
+		assert.Contains(t, m, "Timestamp_u")
+		assert.Contains(t, m, "X-Trace")
+		assert.Contains(t, m, "Backtrace")
+		assert.Equal(t, "1", m["_V"])
+		assert.Equal(t, "testClass", m["ErrorClass"])
+		assert.IsType(t, "", m["Backtrace"])
+	}
+	assert.True(t, foundErrEvt)
+}


### PR DESCRIPTION
The main items are:

- Add `Spec` KV with value `error`
- Ensure all the error events have the mentioned KV
- Ensure `Layer` KV is reported if available