### PR TITLE
AO-9947: logging improvements

### DIFF
--- a/v1/ao/agent.go
+++ b/v1/ao/agent.go
@@ -1,0 +1,49 @@
+// Copyright (C) 2016 Librato, Inc. All rights reserved.
+
+package ao
+
+import (
+	"context"
+
+	aolog "github.com/appoptics/appoptics-apm-go/v1/ao/internal/log"
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
+	"github.com/pkg/errors"
+)
+
+var (
+	errInvalidLogLevel = errors.New("invalid log level")
+)
+
+// WaitForReady checks if the agent is ready. It will block until the agent is ready
+// or the context is canceled.
+//
+// The agent is considered ready if there is a valid default setting for sampling.
+func WaitForReady(ctx context.Context) bool {
+	return reporter.WaitForReady(ctx)
+}
+
+// Shutdown flush the metrics and stops the agent. The call will block until the agent
+// flushes and is successfully shutdown or the context is canceled. It returns nil
+// for successful shutdown and or error when the context is canceled or the agent
+// has already been closed before.
+//
+// This function should be called only once.
+func Shutdown(ctx context.Context) error {
+	return reporter.Shutdown(ctx)
+}
+
+// SetLogLevel changes the logging level of the AppOptics agent
+// Valid logging levels: DEBUG, INFO, WARN, ERROR
+func SetLogLevel(level string) error {
+	l, ok := aolog.ToLogLevel(level)
+	if !ok {
+		return errInvalidLogLevel
+	}
+	aolog.SetLevel(l)
+	return nil
+}
+
+// GetLogLevel returns the current logging level of the AppOptics agent
+func GetLogLevel() string {
+	return aolog.LevelStr[aolog.Level()]
+}

--- a/v1/ao/agent_test.go
+++ b/v1/ao/agent_test.go
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 Librato, Inc. All rights reserved.
+
+package ao
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetGetLogLevel(t *testing.T) {
+	oldLevel := GetLogLevel()
+
+	err := SetLogLevel("INVALID")
+	assert.Equal(t, err, errInvalidLogLevel)
+
+	nl := "ERROR"
+	err = SetLogLevel(nl)
+	assert.Nil(t, err)
+
+	newLevel := GetLogLevel()
+	assert.Equal(t, newLevel, nl)
+
+	SetLogLevel(oldLevel)
+}

--- a/v1/ao/internal/log/logging.go
+++ b/v1/ao/internal/log/logging.go
@@ -159,16 +159,14 @@ func logIt(level LogLevel, msg string, args []interface{}) {
 		// skip = 2 is used here as there are wrappers on top of `logIt` (Info,
 		// Infof, Error, etc). By skipping two layers (logIt and its wrapper), you may get
 		// the information of real callers of the logging functions.
-		pc, file, line, ok := runtime.Caller(numberOfLayersToSkip)
+		_, file, line, ok := runtime.Caller(numberOfLayersToSkip)
 		if ok {
-			path := strings.Split(runtime.FuncForPC(pc).Name(), ".")
-			name := path[len(path)-1]
-			pre = fmt.Sprintf("%s %s#%d %s(): ", LevelStr[level], filepath.Base(file), line, name)
+			pre = fmt.Sprintf("%-5s [AO] %s:%d ", LevelStr[level], filepath.Base(file), line)
 		} else {
-			pre = fmt.Sprintf("%s %s#%s %s(): ", LevelStr[level], "na", "na", "na")
+			pre = fmt.Sprintf("%-5s [AO] %s:%s ", LevelStr[level], "na", "na")
 		}
 	} else { // avoid expensive reflections in production
-		pre = fmt.Sprintf("%s ", LevelStr[level])
+		pre = fmt.Sprintf("%-5s [AO] ", LevelStr[level])
 	}
 
 	buffer.WriteString(pre)

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -211,6 +211,7 @@ type grpcReporter struct {
 // gRPC reporter errors
 var (
 	ErrShutdownClosedReporter = errors.New("trying to shutdown a closed reporter")
+	ErrShutdownTimeout        = errors.New("Shutdown timeout")
 	ErrReporterIsClosed       = errors.New("the reporter is closed")
 	ErrMaxRetriesExceeded     = errors.New("maximum retries exceeded")
 )
@@ -355,7 +356,7 @@ func (r *grpcReporter) Shutdown(ctx context.Context) error {
 			select {
 			case <-r.flushed():
 			case <-ctx.Done():
-				err = errors.New("Shutdown timeout")
+				err = ErrShutdownTimeout
 			}
 
 			r.closeConns()

--- a/v1/ao/internal/reporter/reporter_test.go
+++ b/v1/ao/internal/reporter/reporter_test.go
@@ -469,7 +469,7 @@ func TestInvokeRPC(t *testing.T) {
 	mockMethod.On("Call", mock.Anything, mock.Anything).
 		Return(nil)
 	mockMethod.On("MessageLen").Return(int64(0))
-
+	mockMethod.On("Arg").Return("testArg")
 	mockMethod.On("ResultCode", mock.Anything, mock.Anything).
 		Return(pb.ResultCode_OK)
 
@@ -484,6 +484,7 @@ func TestInvokeRPC(t *testing.T) {
 	mockMethod.On("Call", mock.Anything, mock.Anything).
 		Return(nil)
 	mockMethod.On("MessageLen").Return(int64(0))
+	mockMethod.On("Arg").Return("testArg")
 	mockMethod.On("ResultCode", mock.Anything, mock.Anything).
 		Return(pb.ResultCode_INVALID_API_KEY)
 
@@ -496,6 +497,7 @@ func TestInvokeRPC(t *testing.T) {
 	mockMethod.On("Call", mock.Anything, mock.Anything).
 		Return(nil)
 	mockMethod.On("MessageLen").Return(int64(0))
+	mockMethod.On("Arg").Return("testArg")
 	mockMethod.On("ResultCode", mock.Anything, mock.Anything).
 		Return(pb.ResultCode_LIMIT_EXCEEDED)
 	mockMethod.On("String").Return("test")
@@ -509,6 +511,7 @@ func TestInvokeRPC(t *testing.T) {
 
 	mockMethod = &mocks.Method{}
 	mockMethod.On("MessageLen").Return(int64(0))
+	mockMethod.On("Arg").Return("testArg")
 	mockMethod.On("RetryOnErr", mock.Anything, mock.Anything).
 		Return(true)
 	mockMethod.On("ResultCode", mock.Anything, mock.Anything).

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -314,21 +314,3 @@ func (t *nullTrace) recordMetrics()               {}
 
 // NewNullTrace returns a trace that is not sampled.
 func NewNullTrace() Trace { return &nullTrace{} }
-
-// WaitForReady checks if the agent is ready. It will block until the agent is ready
-// or the context is canceled.
-//
-// The agent is considered ready if there is a valid default setting for sampling.
-func WaitForReady(ctx context.Context) bool {
-	return reporter.WaitForReady(ctx)
-}
-
-// Shutdown flush the metrics and stops the agent. The call will block until the agent
-// flushes and is successfully shutdown or the context is canceled. It returns nil
-// for successful shutdown and or error when the context is canceled or the agent
-// has already been closed before.
-//
-// This function should be called only once.
-func Shutdown(ctx context.Context) error {
-	return reporter.Shutdown(ctx)
-}


### PR DESCRIPTION
Made some changes to the logging:

- add a prefix [AO] before all lines
- remove the function name from logs in DEBUG level
- print Arg returned by the collector for all RPC calls
- expose an API to change the log level on-the-fly to make it easier to be integrated to the user application.