### PR TITLE
AO-10071: Fix Method APIs for unissued RPC requests

### DIFF
--- a/v1/ao/http_instrumentation_test.go
+++ b/v1/ao/http_instrumentation_test.go
@@ -18,13 +18,14 @@ import (
 
 	"os"
 
+	"context"
+
 	"github.com/appoptics/appoptics-apm-go/v1/ao"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/config"
 	g "github.com/appoptics/appoptics-apm-go/v1/ao/internal/graphtest"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"context"
 )
 
 func handler404(w http.ResponseWriter, r *http.Request)      { w.WriteHeader(404) }
@@ -188,7 +189,7 @@ func TestHTTPSpan(t *testing.T) {
 	assert.False(t, m.HasError)
 	assert.InDelta(t, (25*time.Millisecond + nullDuration).Seconds(),
 		m.Duration.Seconds(), (10 * time.Millisecond).Seconds(),
-		nullDuration, m.Duration)
+		nullDuration, fmt.Sprintf("%v", m.Duration))
 
 	m, ok = r.SpanMessages[3].(*reporter.HTTPSpanMessage)
 	assert.True(t, ok)
@@ -622,7 +623,7 @@ func AliceHandler(w http.ResponseWriter, r *http.Request) {
 	defer resp.Body.Close()
 	buf, err := ioutil.ReadAll(resp.Body)
 	l.End() // end HTTP client timing
-	//w.WriteHeader(200)
+	// w.WriteHeader(200)
 	if err != nil {
 		w.Write([]byte(`{"error":true}`))
 	} else {

--- a/v1/ao/internal/reporter/methods.go
+++ b/v1/ao/internal/reporter/methods.go
@@ -59,22 +59,29 @@ func (pe *PostEventsMethod) String() string {
 	return "PostEvents"
 }
 
+// ResultCode returns the result code of the PostEvents RPC call. This method
+// should only be invoked after the method Call is called.
 func (pe *PostEventsMethod) ResultCode() collector.ResultCode {
 	return pe.Resp.Result
 }
 
+// Arg returns the Arg of the PostEvents RPC call. This method
+// should only be invoked after the method Call is called.
 func (pe *PostEventsMethod) Arg() string {
 	return pe.Resp.Arg
 }
 
+// MessageLen returns the length of the PostEvents RPC message body.
 func (pe *PostEventsMethod) MessageLen() int64 {
 	return int64(len(pe.messages))
 }
 
+// Message returns the message body of the RPC call
 func (pe *PostEventsMethod) Message() [][]byte {
 	return pe.messages
 }
 
+// Call issues an RPC call with the provided information
 func (pe *PostEventsMethod) Call(ctx context.Context,
 	c collector.TraceCollectorClient) error {
 	request := &collector.MessageRequest{
@@ -90,12 +97,15 @@ func (pe *PostEventsMethod) Call(ctx context.Context,
 	return err
 }
 
+// CallSummary returns a string representation of the RPC call result.
+// It is mainly used for debug printing.
 func (pe *PostEventsMethod) CallSummary() string {
 	rsp := fmt.Sprintf("%v %s", pe.Resp.Result, pe.Resp.Arg)
 	return fmt.Sprintf("[%s] sent %d events, rtt=%v. rsp=%s",
 		pe, pe.MessageLen(), pe.rtt, rsp)
 }
 
+// RetryOnErr denotes if retry is needed for this RPC method
 func (pe *PostEventsMethod) RetryOnErr() bool {
 	return true
 }
@@ -119,22 +129,28 @@ func (pm *PostMetricsMethod) String() string {
 	return "PostMetrics"
 }
 
+// ResultCode returns the result code of the RPC call. This method should
+// only be called after the method Call is invoked.
 func (pm *PostMetricsMethod) ResultCode() collector.ResultCode {
 	return pm.Resp.Result
 }
 
+// Arg returns the Arg of the RPC call result
 func (pm *PostMetricsMethod) Arg() string {
 	return pm.Resp.Arg
 }
 
+// MessageLen returns the length of the RPC call message.
 func (pm *PostMetricsMethod) MessageLen() int64 {
 	return int64(len(pm.messages))
 }
 
+// Message returns the message body of the RPC call.
 func (pm *PostMetricsMethod) Message() [][]byte {
 	return pm.messages
 }
 
+// Call issues an RPC request with the provided information.
 func (pm *PostMetricsMethod) Call(ctx context.Context,
 	c collector.TraceCollectorClient) error {
 	request := &collector.MessageRequest{
@@ -150,11 +166,14 @@ func (pm *PostMetricsMethod) Call(ctx context.Context,
 	return err
 }
 
+// CallSummary returns a string representation of the RPC call result. It is
+// mainly used for debug printing.
 func (pm *PostMetricsMethod) CallSummary() string {
 	rsp := fmt.Sprintf("%v %s", pm.Resp.Result, pm.Resp.Arg)
 	return fmt.Sprintf("[%s] sent metrics, rtt=%v. rsp=%s", pm, pm.rtt, rsp)
 }
 
+// RetryOnErr denotes if retry is needed for this RPC method
 func (pm *PostMetricsMethod) RetryOnErr() bool {
 	return true
 }
@@ -178,22 +197,27 @@ func (ps *PostStatusMethod) String() string {
 	return "PostStatus"
 }
 
+// ResultCode returns the result code of the RPC call.
 func (ps *PostStatusMethod) ResultCode() collector.ResultCode {
 	return ps.Resp.Result
 }
 
+// Arg returns the Arg of the RPC call result.
 func (ps *PostStatusMethod) Arg() string {
 	return ps.Resp.Arg
 }
 
+// MessageLen returns the length of the RPC call message body
 func (ps *PostStatusMethod) MessageLen() int64 {
 	return int64(len(ps.messages))
 }
 
+// Message returns the RPC call message body
 func (ps *PostStatusMethod) Message() [][]byte {
 	return ps.messages
 }
 
+// Call issues an RPC call with the provided information.
 func (ps *PostStatusMethod) Call(ctx context.Context,
 	c collector.TraceCollectorClient) error {
 	request := &collector.MessageRequest{
@@ -209,10 +233,13 @@ func (ps *PostStatusMethod) Call(ctx context.Context,
 	return err
 }
 
+// RetryOnErr denotes if retry is needed for this RPC method
 func (ps *PostStatusMethod) RetryOnErr() bool {
 	return true
 }
 
+// CallSummary returns a string representation for the RPC call result. It is
+// mainly used for debug printing.
 func (ps *PostStatusMethod) CallSummary() string {
 	rsp := fmt.Sprintf("%v %s", ps.Resp.Result, ps.Resp.Arg)
 	return fmt.Sprintf("[%s] sent status, rtt=%v. rsp=%s", ps, ps.rtt, rsp)
@@ -235,22 +262,27 @@ func (gs *GetSettingsMethod) String() string {
 	return "GetSettings"
 }
 
+// ResultCode returns the result code of the RPC call
 func (gs *GetSettingsMethod) ResultCode() collector.ResultCode {
 	return gs.Resp.Result
 }
 
+// Arg returns the Arg of the RPC call result
 func (gs *GetSettingsMethod) Arg() string {
 	return gs.Resp.Arg
 }
 
-func (ps *GetSettingsMethod) MessageLen() int64 {
+// MessageLen returns the length of the RPC message body.
+func (gs *GetSettingsMethod) MessageLen() int64 {
 	return 0
 }
 
-func (ps *GetSettingsMethod) Message() [][]byte {
+// Message returns the message body of the RPC call.
+func (gs *GetSettingsMethod) Message() [][]byte {
 	return nil
 }
 
+// Call issues an RPC call.
 func (gs *GetSettingsMethod) Call(ctx context.Context,
 	c collector.TraceCollectorClient) error {
 	request := &collector.SettingsRequest{
@@ -265,15 +297,18 @@ func (gs *GetSettingsMethod) Call(ctx context.Context,
 	return err
 }
 
+// CallSummary returns a string representation of the RPC call result.
 func (gs *GetSettingsMethod) CallSummary() string {
 	rsp := fmt.Sprintf("%v %s", gs.Resp.Result, gs.Resp.Arg)
 	return fmt.Sprintf("[%s] got settings, rtt=%v. rsp=%s", gs, gs.rtt, rsp)
 }
 
+// RetryOnErr denotes if this method needs a retry on failure.
 func (gs *GetSettingsMethod) RetryOnErr() bool {
 	return true
 }
 
+// PingMethod defines the RPC method `Ping`
 type PingMethod struct {
 	conn       string
 	serviceKey string
@@ -292,22 +327,27 @@ func (p *PingMethod) String() string {
 	return "Ping " + p.conn
 }
 
+// ResultCode returns the code of the RPC call result
 func (p *PingMethod) ResultCode() collector.ResultCode {
 	return p.Resp.Result
 }
 
+// Arg returns the arg of the RPC call result
 func (p *PingMethod) Arg() string {
 	return p.Resp.Arg
 }
 
+// MessageLen returns the length of the RPC call message body.
 func (p *PingMethod) MessageLen() int64 {
 	return 0
 }
 
+// Message returns the message body, if any.
 func (p *PingMethod) Message() [][]byte {
 	return nil
 }
 
+// Call makes an RPC call with the information provided.
 func (p *PingMethod) Call(ctx context.Context,
 	c collector.TraceCollectorClient) error {
 	request := &collector.PingRequest{
@@ -320,11 +360,14 @@ func (p *PingMethod) Call(ctx context.Context,
 	return err
 }
 
+// CallSummary returns a string representation for the RPC call result. It is
+// mainly used for debug printing.
 func (p *PingMethod) CallSummary() string {
 	rsp := fmt.Sprintf("%v %s", p.Resp.Result, p.Resp.Arg)
 	return fmt.Sprintf("[%s] ping back, rtt=%v. rsp=%s", p, p.rtt, rsp)
 }
 
+// RetryOnErr denotes if this RPC method needs a retry on failure.
 func (p *PingMethod) RetryOnErr() bool {
 	return false
 }

--- a/v1/ao/internal/reporter/methods.go
+++ b/v1/ao/internal/reporter/methods.go
@@ -45,6 +45,7 @@ type Method interface {
 
 var (
 	errRPCNotIssued = errors.New("RPC request is not issued yet")
+	errGotNilResp   = errors.New("got nil resp from collector")
 )
 
 // PostEventsMethod is the struct for RPC method PostEvents
@@ -393,12 +394,18 @@ func resultRespStr(r *collector.MessageResult, err error) string {
 	if err != nil {
 		return err.Error()
 	}
+	if r == nil {
+		return errGotNilResp.Error()
+	}
 	return fmt.Sprintf("%v %s", r.Result, r.Arg)
 }
 
 func settingsRespStr(r *collector.SettingsResult, err error) string {
 	if err != nil {
 		return err.Error()
+	}
+	if r == nil {
+		return errGotNilResp.Error()
 	}
 	return fmt.Sprintf("%v %s", r.Result, r.Arg)
 }

--- a/v1/ao/internal/reporter/methods_test.go
+++ b/v1/ao/internal/reporter/methods_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter/collector"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter/mocks"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -119,4 +120,19 @@ func TestPingMethod(t *testing.T) {
 	assert.Equal(t, collector.ResultCode_OK, code)
 	assert.Nil(t, err)
 	assert.Equal(t, "", pe.Arg())
+}
+
+func TestGenericMethod(t *testing.T) {
+	// test CallSummary before making the RPC call
+	pe := newPingMethod("test-ket", "testConn")
+	assert.Contains(t, pe.CallSummary(), errRPCNotIssued.Error())
+
+	// test CallSummary when the RPC call fails
+	mockTC := &mocks.TraceCollectorClient{}
+	err := errors.New("err connection aborted")
+	mockTC.On("Ping", mock.Anything, mock.Anything).
+		Return(nil, err)
+	pe.Call(context.Background(), mockTC)
+	assert.Contains(t, pe.CallSummary(), err.Error())
+
 }

--- a/v1/ao/internal/reporter/methods_test.go
+++ b/v1/ao/internal/reporter/methods_test.go
@@ -30,7 +30,9 @@ func TestPostEventsMethod(t *testing.T) {
 
 	err := pe.Call(context.Background(), mockTC)
 	assert.Nil(t, err)
-	assert.Equal(t, collector.ResultCode_OK, pe.ResultCode())
+	code, err := pe.ResultCode()
+	assert.Equal(t, collector.ResultCode_OK, code)
+	assert.Nil(t, err)
 	assert.Equal(t, "", pe.Arg())
 }
 
@@ -52,7 +54,9 @@ func TestPostMetricsMethod(t *testing.T) {
 
 	err := pe.Call(context.Background(), mockTC)
 	assert.Nil(t, err)
-	assert.Equal(t, collector.ResultCode_OK, pe.ResultCode())
+	code, err := pe.ResultCode()
+	assert.Equal(t, collector.ResultCode_OK, code)
+	assert.Nil(t, err)
 	assert.Equal(t, "", pe.Arg())
 }
 
@@ -74,7 +78,8 @@ func TestPostStatusMethod(t *testing.T) {
 
 	err := pe.Call(context.Background(), mockTC)
 	assert.Nil(t, err)
-	assert.Equal(t, collector.ResultCode_OK, pe.ResultCode())
+	code, err := pe.ResultCode()
+	assert.Equal(t, collector.ResultCode_OK, code)
 	assert.Equal(t, "", pe.Arg())
 }
 
@@ -91,7 +96,9 @@ func TestGetSettingsMethod(t *testing.T) {
 
 	err := pe.Call(context.Background(), mockTC)
 	assert.Nil(t, err)
-	assert.Equal(t, collector.ResultCode_OK, pe.ResultCode())
+	code, err := pe.ResultCode()
+	assert.Equal(t, collector.ResultCode_OK, code)
+	assert.Nil(t, err)
 	assert.Equal(t, "", pe.Arg())
 }
 
@@ -108,6 +115,8 @@ func TestPingMethod(t *testing.T) {
 
 	err := pe.Call(context.Background(), mockTC)
 	assert.Nil(t, err)
-	assert.Equal(t, collector.ResultCode_OK, pe.ResultCode())
+	code, err := pe.ResultCode()
+	assert.Equal(t, collector.ResultCode_OK, code)
+	assert.Nil(t, err)
 	assert.Equal(t, "", pe.Arg())
 }

--- a/v1/ao/internal/reporter/mocks/Method.go
+++ b/v1/ao/internal/reporter/mocks/Method.go
@@ -84,7 +84,7 @@ func (_m *Method) MessageLen() int64 {
 }
 
 // ResultCode provides a mock function with given fields:
-func (_m *Method) ResultCode() collector.ResultCode {
+func (_m *Method) ResultCode() (collector.ResultCode, error) {
 	ret := _m.Called()
 
 	var r0 collector.ResultCode
@@ -94,7 +94,14 @@ func (_m *Method) ResultCode() collector.ResultCode {
 		r0 = ret.Get(0).(collector.ResultCode)
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // RetryOnErr provides a mock function with given fields:

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -455,7 +455,7 @@ func (c *grpcConnection) connect() error {
 	// Skip it if the connection is not stale - someone else may have done
 	// the connection.
 	if c.isActive() {
-		log.Debug("[%s] Someone else has done the redirection.", c.name)
+		log.Debugf("[%s] Someone else has done the redirection.", c.name)
 		return nil
 	}
 	// create a new connection object for this client

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -1070,7 +1070,7 @@ func (c *grpcConnection) InvokeRPC(exit chan struct{}, m Method) error {
 			failsNum = 0
 
 			// server responded, check the result code and perform actions accordingly
-			switch result := m.ResultCode(); result {
+			switch result, _ := m.ResultCode(); result {
 			case collector.ResultCode_OK:
 				atomic.AddInt64(&c.queueStats.numSent, m.MessageLen())
 				return nil

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -734,7 +734,7 @@ func (r *grpcReporter) eventBatchSender(batches <-chan [][]byte) {
 			case nil:
 				log.Info(method.CallSummary())
 			default:
-				log.Infof("eventBatchSender: %s", err)
+				log.Warningf("eventBatchSender: %s", err)
 			}
 		}
 
@@ -784,7 +784,7 @@ func (r *grpcReporter) sendMetrics(msg []byte) {
 	case nil:
 		log.Info(method.CallSummary())
 	default:
-		log.Infof("sendMetrics: %s", err)
+		log.Warningf("sendMetrics: %s", err)
 	}
 }
 

--- a/v1/ao/internal/reporter/reporter_test.go
+++ b/v1/ao/internal/reporter/reporter_test.go
@@ -462,7 +462,7 @@ func TestInvokeRPC(t *testing.T) {
 	mockMethod.On("CallSummary").Return("summary")
 	mockMethod.On("Arg").Return("testArg")
 	mockMethod.On("ResultCode", mock.Anything, mock.Anything).
-		Return(pb.ResultCode_OK)
+		Return(pb.ResultCode_OK, nil)
 
 	exit := make(chan struct{})
 	close(exit)
@@ -480,7 +480,7 @@ func TestInvokeRPC(t *testing.T) {
 	mockMethod.On("CallSummary").Return("summary")
 	mockMethod.On("Arg").Return("testArg")
 	mockMethod.On("ResultCode", mock.Anything, mock.Anything).
-		Return(pb.ResultCode_INVALID_API_KEY)
+		Return(pb.ResultCode_INVALID_API_KEY, nil)
 
 	assert.Equal(t, errInvalidServiceKey, c.InvokeRPC(exit, mockMethod))
 
@@ -494,7 +494,7 @@ func TestInvokeRPC(t *testing.T) {
 	mockMethod.On("CallSummary").Return("summary")
 	mockMethod.On("Arg").Return("testArg")
 	mockMethod.On("ResultCode", mock.Anything, mock.Anything).
-		Return(pb.ResultCode_LIMIT_EXCEEDED)
+		Return(pb.ResultCode_LIMIT_EXCEEDED, nil)
 
 	mockMethod.On("RetryOnErr", mock.Anything, mock.Anything).
 		Return(false)
@@ -512,7 +512,7 @@ func TestInvokeRPC(t *testing.T) {
 	mockMethod.On("RetryOnErr", mock.Anything, mock.Anything).
 		Return(true)
 	mockMethod.On("ResultCode", mock.Anything, mock.Anything).
-		Return(pb.ResultCode_OK)
+		Return(pb.ResultCode_OK, nil)
 
 	mockMethod.On("Call", mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, c pb.TraceCollectorClient) error {
@@ -546,7 +546,7 @@ func TestInvokeRPC(t *testing.T) {
 			} else {
 				return pb.ResultCode_REDIRECT
 			}
-		})
+		}, nil)
 
 	mockMethod.On("Call", mock.Anything, mock.Anything).
 		Return(nil)


### PR DESCRIPTION
Ref: https://swicloud.atlassian.net/browse/AO-10071

The main purpose of this PR:
- add the second return value (`error`) to the API `ResultCode` to indicate if the RPC is issued successfully, or not yet issued at all. By this way the method `CallSummary` knows whether it can access the RPC result (if not yet called or failed the `.Resp` field may be a null pointer).

Some other fixes/improvements:
- print the error in the call summary if the RPC is not successful
- change the log level of failed RPC calls to WARNING (the default level)
- other minor fixes (e.g., inconsistent receiver names of the struct methods)