### PR TITLE
AO-10033: Per Request X-Trace ID

### DIFF
--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -221,13 +221,11 @@ func (t *aoTrace) IsSampled() bool { return t != nil && t.aoCtx.IsSampled() }
 // ExitMetadata reports the X-Trace metadata string that will be used by the exit event.
 // This is useful for setting response headers before reporting the end of the span.
 func (t *aoTrace) ExitMetadata() (mdHex string) {
-	if t.IsSampled() {
-		if t.exitEvent == nil {
-			t.exitEvent = t.aoCtx.NewEvent(reporter.LabelExit, t.layerName(), false)
-		}
-		if t.exitEvent != nil {
-			mdHex = t.exitEvent.MetadataString()
-		}
+	if t.exitEvent == nil {
+		t.exitEvent = t.aoCtx.NewEvent(reporter.LabelExit, t.layerName(), false)
+	}
+	if t.exitEvent != nil {
+		mdHex = t.exitEvent.MetadataString()
 	}
 	return
 }

--- a/v1/ao/trace_test.go
+++ b/v1/ao/trace_test.go
@@ -42,7 +42,7 @@ func TestNoTraceMetadata(t *testing.T) {
 	md := tr.ExitMetadata()
 	tr.EndCallback(func() ao.KVMap { return ao.KVMap{"Not": "reported"} })
 
-	assert.Equal(t, md, "")
+	assert.NotEqual(t, "", md)
 	assert.Len(t, r.EventBufs, 0)
 }
 
@@ -307,7 +307,7 @@ func TestNoTraceFromMetadata(t *testing.T) {
 	md := tr.ExitMetadata()
 	tr.End()
 
-	assert.Equal(t, md, "")
+	assert.NotEqual(t, "", md)
 	assert.Len(t, r.EventBufs, 0)
 }
 func TestNoTraceFromBadMetadata(t *testing.T) {
@@ -318,7 +318,7 @@ func TestNoTraceFromBadMetadata(t *testing.T) {
 	tr := ao.NewTraceFromID("test", incomingID, nil)
 	md := tr.ExitMetadata()
 	tr.End("Edge", "823723875") // should not report
-	assert.Equal(t, "", md)
+	assert.NotEqual(t, "", md)
 	assert.Len(t, r.EventBufs, 0)
 }
 


### PR DESCRIPTION
Ref: https://swicloud.atlassian.net/browse/AO-10033

Attach the X-Trace ID to the HTTP header of every request, no matter whether it is sampled or not.

The commit removes the sampling check in `ExitMetadata` and make it returns the metadata unconditionally.