### PR TITLE
AO-10063: Fix Version Strings

### DIFF
--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -122,7 +122,7 @@ func sendInitMessage() {
 
 		e.AddKV("__Init", 1)
 		e.AddKV("Go.Version", utils.GoVersion())
-		e.AddKV("Go.Oboe.Version", utils.Version())
+		e.AddKV("Go.AppOptics.Version", utils.Version())
 
 		e.ReportStatus(c)
 	}

--- a/v1/ao/internal/reporter/oboe_test.go
+++ b/v1/ao/internal/reporter/oboe_test.go
@@ -34,7 +34,7 @@ func assertInitMessage(t *testing.T, bufs [][]byte) {
 	g.AssertGraph(t, bufs, 1, g.AssertNodeMap{
 		{"go", "single"}: {Edges: g.Edges{}, Callback: func(n g.Node) {
 			assert.Equal(t, 1, n.Map["__Init"])
-			assert.Equal(t, utils.Version(), n.Map["Go.Oboe.Version"])
+			assert.Equal(t, utils.Version(), n.Map["Go.AppOptics.Version"])
 			assert.NotEmpty(t, n.Map["Go.Version"])
 		}},
 	})

--- a/v1/ao/internal/utils/version.go
+++ b/v1/ao/internal/utils/version.go
@@ -1,13 +1,16 @@
 package utils
 
-import "runtime"
+import (
+	"runtime"
+	"strings"
+)
 
 var (
 	// The AppOptics Go agent version
-	version = "v1.3.0"
+	version = "1.3.0"
 
 	// The Go version
-	goVersion = runtime.Version()
+	goVersion = strings.TrimPrefix(runtime.Version(), "go")
 )
 
 // Version returns the agent's version


### PR DESCRIPTION
Ref: https://swicloud.atlassian.net/browse/AO-10063

The following changes have been committed to this branch:

- trim the prefix `go` from the golang version string
- remvoe the prefix `v` from the AppOptics version string
- rename the event key `Go.Oboe.Version` to `Go.AppOptics.Version`