### PR TITLE
AO-8851: Short-circuit the tracing when the reporter is closed

### DIFF
--- a/v1/ao/agent.go
+++ b/v1/ao/agent.go
@@ -71,6 +71,12 @@ func Shutdown(ctx context.Context) error {
 	return reporter.Shutdown(ctx)
 }
 
+// Closed denotes if the agent is closed (by either calling Shutdown explicitly
+// or being triggered from some internal error).
+func Closed() bool {
+	return reporter.Closed()
+}
+
 // SetLogLevel changes the logging level of the AppOptics agent
 // Valid logging levels: DEBUG, INFO, WARN, ERROR
 func SetLogLevel(level string) error {

--- a/v1/ao/agent.go
+++ b/v1/ao/agent.go
@@ -53,11 +53,16 @@ func Disabled() bool {
 	return disabled
 }
 
-// WaitForReady checks if the agent is ready. It will block until the agent is ready
-// or the context is canceled.
+// WaitForReady checks if the agent is ready. It returns true is the agent is ready,
+// or false if it is not.
 //
+// A call to this method will block until the agent is ready or the context is
+// canceled, or the agent is already closed.
 // The agent is considered ready if there is a valid default setting for sampling.
 func WaitForReady(ctx context.Context) bool {
+	if Closed() {
+		return false
+	}
 	return reporter.WaitForReady(ctx)
 }
 

--- a/v1/ao/agent.go
+++ b/v1/ao/agent.go
@@ -26,15 +26,10 @@ var (
 	// It is initialized when the package is imported and won't be changed
 	// in runtime.
 	disabled = false
-
-	// This flag indicates whether the domain name needs to be prepended to
-	// the transaction name of the span message
-	trxNamePrependDomain = false
 )
 
 func init() {
 	initDisabled()
-	initTrxNamePrependDomain()
 }
 
 func initDisabled() {
@@ -42,10 +37,6 @@ func initDisabled() {
 	if disabled {
 		aolog.Warningf("AppOptics agent is disabled.")
 	}
-}
-
-func initTrxNamePrependDomain() {
-	trxNamePrependDomain = config.GetPrependDomain()
 }
 
 // Disabled indicates if the agent is disabled

--- a/v1/ao/agent_test.go
+++ b/v1/ao/agent_test.go
@@ -3,7 +3,9 @@
 package ao
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -22,4 +24,12 @@ func TestSetGetLogLevel(t *testing.T) {
 	assert.Equal(t, newLevel, nl)
 
 	SetLogLevel(oldLevel)
+}
+
+func TestShutdown(t *testing.T) {
+	Shutdown(context.Background())
+	assert.True(t, Closed())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Hour*24)
+	defer cancel()
+	assert.False(t, WaitForReady(ctx))
 }

--- a/v1/ao/http_instrumentation.go
+++ b/v1/ao/http_instrumentation.go
@@ -40,6 +40,11 @@ func HTTPHandler(handler func(http.ResponseWriter, *http.Request)) func(http.Res
 	}
 	// return wrapped HTTP request handler
 	return func(w http.ResponseWriter, r *http.Request) {
+		if Closed() {
+			handler(w, r)
+			return
+		}
+
 		t, w, r := TraceFromHTTPRequestResponse(httpHandlerSpanName, w, r)
 		defer t.End(endArgs...)
 

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -17,6 +17,7 @@ import (
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/config"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/log"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/utils"
+	"github.com/pkg/errors"
 )
 
 // Current settings configuration
@@ -111,6 +112,10 @@ func readEnvSettings() {
 }
 
 func sendInitMessage() {
+	if Closed() {
+		log.Info(errors.Wrap(ErrReporterIsClosed, "send init message"))
+		return
+	}
 	ctx := newContext(true)
 	if c, ok := ctx.(*oboeContext); ok {
 		// create new event from context

--- a/v1/ao/internal/reporter/reporter.go
+++ b/v1/ao/internal/reporter/reporter.go
@@ -110,6 +110,11 @@ func Shutdown(ctx context.Context) error {
 	return globalReporter.Shutdown(ctx)
 }
 
+// Closed indicates if the reporter has been shutdown
+func Closed() bool {
+	return globalReporter.Closed()
+}
+
 // ReportSpan is called from the app when a span message is available
 // span	span message to be put on the channel
 //

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -357,6 +357,7 @@ func (r *grpcReporter) Shutdown(ctx context.Context) error {
 			}
 
 			r.closeConns()
+			r.setReady(false)
 			host.Stop()
 			log.Warning("AppOptics agent is stopped.")
 		})

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -85,7 +85,7 @@ func (t *aoTrace) aoContext() reporter.Context { return t.aoCtx }
 // the beginning of a root span named spanName. If this trace is sampled, it may report
 // event data to AppOptics; otherwise event reporting will be a no-op.
 func NewTrace(spanName string) Trace {
-	if Disabled() {
+	if Disabled() || Closed() {
 		return NewNullTrace()
 	}
 
@@ -104,7 +104,7 @@ func NewTrace(spanName string) Trace {
 // incoming trace ID (e.g. from a incoming RPC or service call's "X-Trace" header).
 // If callback is provided & trace is sampled, cb will be called for entry event KVs
 func NewTraceFromID(spanName, mdstr string, cb func() KVMap) Trace {
-	if Disabled() {
+	if Disabled() || Closed() {
 		return NewNullTrace()
 	}
 


### PR DESCRIPTION
Ref: https://swicloud.atlassian.net/browse/AO-8851

Do the following action to short-circuit the tracing when the agent is closed:
- Do not create new traces
- Return false immediately in `WaitForReady` when the reporter is closed
- Skip sending `__Init` message