### PR TITLE
AO-8901: print Go version in log, fix a code error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ func myHandler( w http.ResponseWriter, r *http.Request ) {
     q1L.End()
 
     fmt.Fprintf(w, "I ran a query")
+}
 
 func main() {
     http.HandleFunc("/endpoint", ao.HTTPHandler(myHandler))

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -283,8 +283,8 @@ func newGRPCReporter() reporter {
 
 	r.start()
 
-	log.Warningf("AppOptics reporter is initialized. id: %v version: %s.",
-		r.done, utils.Version())
+	log.Warningf("AppOptics reporter v%s is initialized. id: %v Go version: %s.",
+		utils.Version(), r.done, utils.GoVersion())
 	return r
 }
 


### PR DESCRIPTION
Minor fixes:
- Print the Go version in the log when the agent is started, so it won't need to ask for this information while diagnosing issues.
- Fix a code error in README: a right curly bracket is missing.  (Ref: https://swicloud.atlassian.net/browse/AO-8901)