### PR TITLE
AO-10145: fix spanImpl methods

### DIFF
--- a/v1/ao/layer.go
+++ b/v1/ao/layer.go
@@ -9,8 +9,9 @@ import (
 
 	"errors"
 
-	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
 	"context"
+
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
 )
 
 const (
@@ -49,6 +50,9 @@ type Span interface {
 	// SetAsync(true) provides a hint that this Span is a parent of
 	// concurrent overlapping child Spans.
 	SetAsync(bool)
+
+	// SetOperationName sets or changes the span's operation name
+	SetOperationName(string)
 
 	// SetTransactionName sets this service's transaction name.
 	// It is used for categorizing service metrics and traces in AppOptics.
@@ -181,6 +185,11 @@ func (s *layerSpan) SetAsync(val bool) {
 	}
 }
 
+// SetOperationName sets the name of this span
+func (s *span) SetOperationName(name string) {
+	s.setName(name)
+}
+
 // SetTransactionName sets the transaction name used to categorize service requests in AppOptics.
 func (s *span) SetTransactionName(name string) error {
 	if !s.ok() {
@@ -248,6 +257,7 @@ func (s nullSpan) aoContext() reporter.Context                           { retur
 func (s nullSpan) MetadataString() string                                { return "" }
 func (s nullSpan) IsSampled() bool                                       { return false }
 func (s nullSpan) SetAsync(bool)                                         {}
+func (s nullSpan) SetOperationName(string)                               {}
 func (s nullSpan) SetTransactionName(string) error                       { return nil }
 func (s nullSpan) GetTransactionName() string                            { return "" }
 
@@ -280,6 +290,7 @@ type labeler interface {
 	entryLabel() reporter.Label
 	exitLabel() reporter.Label
 	layerName() string
+	setName(string)
 }
 type spanLabeler struct{ name string }
 type profileLabeler struct{ name string }
@@ -288,9 +299,11 @@ type profileLabeler struct{ name string }
 func (l spanLabeler) entryLabel() reporter.Label    { return reporter.LabelEntry }
 func (l spanLabeler) exitLabel() reporter.Label     { return reporter.LabelExit }
 func (l spanLabeler) layerName() string             { return l.name }
+func (l spanLabeler) setName(name string)           { l.name = name }
 func (l profileLabeler) entryLabel() reporter.Label { return reporter.LabelProfileEntry }
 func (l profileLabeler) exitLabel() reporter.Label  { return reporter.LabelProfileExit }
 func (l profileLabeler) layerName() string          { return "" }
+func (l profileLabeler) setName(name string)        { l.name = name }
 
 func newSpan(aoCtx reporter.Context, spanName string, parent Span, args ...interface{}) Span {
 	ll := spanLabeler{spanName}

--- a/v1/ao/opentracing/tracer.go
+++ b/v1/ao/opentracing/tracer.go
@@ -182,7 +182,7 @@ func (s *spanImpl) SetOperationName(operationName string) ot.Span {
 	s.Lock()
 	defer s.Unlock()
 
-	s.context.span.SetTransactionName(operationName)
+	s.context.span.SetOperationName(operationName)
 	return s
 }
 

--- a/v1/ao/opentracing/tracer.go
+++ b/v1/ao/opentracing/tracer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/opentracing/opentracing-go/log"
 )
 
-// NewTracer returns a new Tracelytics tracer.
+// NewTracer returns a new AppOptics tracer.
 func NewTracer() ot.Tracer {
 	return &Tracer{
 		textMapPropagator: &textMapPropagator{},
@@ -18,7 +18,7 @@ func NewTracer() ot.Tracer {
 	}
 }
 
-// Tracer reports trace data to Tracelytics.
+// Tracer reports trace data to AppOptics.
 type Tracer struct {
 	textMapPropagator  *textMapPropagator
 	binaryPropagator   *binaryPropagator
@@ -86,6 +86,7 @@ type spanImpl struct {
 	context    spanContext
 }
 
+// SetBaggageItem sets the KV as a baggage item.
 func (s *spanImpl) SetBaggageItem(key, val string) ot.Span {
 	s.Lock()
 	defer s.Unlock()
@@ -125,6 +126,7 @@ func (c spanContext) WithBaggageItem(key, val string) spanContext {
 	return spanContext{c.span, c.remoteMD, c.sampled, newBaggage}
 }
 
+// BaggageItem returns the baggage item with the provided key.
 func (s *spanImpl) BaggageItem(key string) string {
 	s.Lock()
 	defer s.Unlock()
@@ -133,6 +135,7 @@ func (s *spanImpl) BaggageItem(key string) string {
 
 const otLogPrefix = "OT-Log-"
 
+// LogFields adds the fields to the span.
 func (s *spanImpl) LogFields(fields ...log.Field) {
 	s.Lock()
 	defer s.Unlock()
@@ -140,26 +143,33 @@ func (s *spanImpl) LogFields(fields ...log.Field) {
 		s.context.span.AddEndArgs(otLogPrefix+field.Key(), field.Value())
 	}
 }
+
+// LogKV adds KVs to the span.
 func (s *spanImpl) LogKV(keyVals ...interface{}) {
 	s.Lock()
 	defer s.Unlock()
 	s.context.span.AddEndArgs(keyVals...)
 }
 
+// Context returns the span context.
 func (s *spanImpl) Context() ot.SpanContext {
 	s.Lock()
 	defer s.Unlock()
 	return s.context
 }
 
+// Finish sets the end timestamp and finalizes Span state.
 func (s *spanImpl) Finish() {
 	s.Lock()
 	defer s.Unlock()
 	s.context.span.End()
 }
 
+// Tracer provides the tracer of this span.
 func (s *spanImpl) Tracer() ot.Tracer { return s.tracer }
 
+// FinishWithOptions is like Finish() but with explicit control over
+// timestamps and log data.
 // XXX handle FinishTime, LogRecords
 func (s *spanImpl) FinishWithOptions(opts ot.FinishOptions) {
 	s.Lock()
@@ -167,7 +177,7 @@ func (s *spanImpl) FinishWithOptions(opts ot.FinishOptions) {
 	s.context.span.End()
 }
 
-// XXX handle changing operation name
+// SetOperationName sets or changes the operation name.
 func (s *spanImpl) SetOperationName(operationName string) ot.Span {
 	s.Lock()
 	defer s.Unlock()
@@ -176,6 +186,7 @@ func (s *spanImpl) SetOperationName(operationName string) ot.Span {
 	return s
 }
 
+// SetTag adds a tag to the span.
 func (s *spanImpl) SetTag(key string, value interface{}) ot.Span {
 	s.Lock()
 	defer s.Unlock()
@@ -183,7 +194,17 @@ func (s *spanImpl) SetTag(key string, value interface{}) ot.Span {
 	return s
 }
 
-// deprecated Log methods are not supported.
-func (s *spanImpl) LogEvent(event string)                                 {}
+// LogEvent logs a event to the span.
+//
+// Deprecated: this method is deprecated.
+func (s *spanImpl) LogEvent(event string) {}
+
+// LogEventWithPayload logs a event with a payload.
+//
+// Deprecated: this method is deprecated.
 func (s *spanImpl) LogEventWithPayload(event string, payload interface{}) {}
-func (s *spanImpl) Log(data ot.LogData)                                   {}
+
+// Log logs the LogData.
+//
+// Deprecated: this method is deprecated.
+func (s *spanImpl) Log(data ot.LogData) {}

--- a/v1/ao/opentracing/tracer.go
+++ b/v1/ao/opentracing/tracer.go
@@ -168,7 +168,13 @@ func (s *spanImpl) FinishWithOptions(opts ot.FinishOptions) {
 }
 
 // XXX handle changing operation name
-func (s *spanImpl) SetOperationName(operationName string) ot.Span { return s }
+func (s *spanImpl) SetOperationName(operationName string) ot.Span {
+	s.Lock()
+	defer s.Unlock()
+
+	s.context.span.SetTransactionName(operationName)
+	return s
+}
 
 func (s *spanImpl) SetTag(key string, value interface{}) ot.Span {
 	s.Lock()


### PR DESCRIPTION
The changes:
- Fix data races of `spanImpl` methods
- Implement the method `SetOperationName`  by adding new methods to the Span interface
- Finish the function docs

Ref: https://swicloud.atlassian.net/browse/AO-10145