### PR TITLE
AO-10162: Optionally include backtrace in events

### DIFF
--- a/v1/ao/client_layer.go
+++ b/v1/ao/client_layer.go
@@ -9,12 +9,10 @@ import "context"
 // query latency heatmaps and charts by span name, query statement, DB host and table.
 // Parameter "flavor" specifies the flavor of the query statement, such as "mysql", "postgresql", or "mongodb".
 // Call or defer the returned Span's End() to time the query's client-side latency.
-func BeginQuerySpan(ctx context.Context, spanName, query, flavor, remoteHost string) Span {
-	l, _ := BeginSpan(ctx, spanName,
-		"Spec", "query",
-		"Query", query,
-		"Flavor", flavor,
-		"RemoteHost", remoteHost)
+func BeginQuerySpan(ctx context.Context, spanName, query, flavor, remoteHost string, args ...interface{}) Span {
+	qsKVs := []interface{}{"Spec", "query", "Query", query, "Flavor", flavor, "RemoteHost", remoteHost}
+	kvs := mergeKVs(qsKVs, args)
+	l, _ := BeginSpan(ctx, spanName, kvs...)
 	return l
 }
 
@@ -24,8 +22,10 @@ func BeginQuerySpan(ctx context.Context, spanName, query, flavor, remoteHost str
 // Filterable hit/miss ratios charts will be available if "hit" is used.
 // Optional parameter "key" will display in the trace's details, but will not be indexed.
 // Call or defer the returned Span's End() to time the request's client-side latency.
-func BeginCacheSpan(ctx context.Context, spanName, op, key, remoteHost string, hit bool) Span {
-	l, _ := BeginSpan(ctx, spanName, "KVOp", op, "KVKey", key, "KVHit", hit, "RemoteHost", remoteHost)
+func BeginCacheSpan(ctx context.Context, spanName, op, key, remoteHost string, hit bool, args ...interface{}) Span {
+	csKVs := []interface{}{"KVOp", op, "KVKey", key, "KVHit", hit, "RemoteHost", remoteHost}
+	kvs := mergeKVs(csKVs, args)
+	l, _ := BeginSpan(ctx, spanName, kvs...)
 	return l
 }
 
@@ -34,16 +34,20 @@ func BeginCacheSpan(ctx context.Context, spanName, op, key, remoteHost string, h
 // package, BeginHTTPClientSpan also reports this metadata, while also propagating trace context
 // metadata headers via http.Request and http.Response.
 // Call or defer the returned Span's End() to time the call's client-side latency.
-func BeginRemoteURLSpan(ctx context.Context, spanName, remoteURL string) Span {
-	l, _ := BeginSpan(ctx, spanName, "IsService", true, "RemoteURL", remoteURL)
+func BeginRemoteURLSpan(ctx context.Context, spanName, remoteURL string, args ...interface{}) Span {
+	rsKVs := []interface{}{"IsService", true, "RemoteURL", remoteURL}
+	kvs := mergeKVs(rsKVs, args)
+	l, _ := BeginSpan(ctx, spanName, kvs...)
 	return l
 }
 
 // BeginRPCSpan returns a Span that reports metadata used by AppOptics to filter RPC call
 // latency heatmaps and charts by span name, protocol, controller, and remote host.
 // Call or defer the returned Span's End() to time the call's client-side latency.
-func BeginRPCSpan(ctx context.Context, spanName, protocol, controller, remoteHost string) Span {
-	l, _ := BeginSpan(ctx, spanName, "IsService", true,
-		"RemoteProtocol", protocol, "RemoteHost", remoteHost, "RemoteController", controller)
+func BeginRPCSpan(ctx context.Context, spanName, protocol, controller, remoteHost string, args ...interface{}) Span {
+	rsKVs := []interface{}{"IsService", true,
+		"RemoteProtocol", protocol, "RemoteHost", remoteHost, "RemoteController", controller}
+	kvs := mergeKVs(rsKVs, args)
+	l, _ := BeginSpan(ctx, spanName, kvs...)
 	return l
 }

--- a/v1/ao/client_layer_test.go
+++ b/v1/ao/client_layer_test.go
@@ -3,6 +3,7 @@
 package ao_test
 
 import (
+	"runtime/debug"
 	"testing"
 	"time"
 
@@ -33,7 +34,7 @@ func TestSpans(t *testing.T) {
 
 	// make a query span
 	l = ao.BeginQuerySpan(ctx, "querySpan", "SELECT * FROM TEST_TABLE",
-		"MySQL", "remote.host")
+		"MySQL", "remote.host", ao.KeyBackTrace, string(debug.Stack()))
 	time.Sleep(time.Millisecond)
 	l.End()
 
@@ -65,7 +66,7 @@ func TestSpans(t *testing.T) {
 			assert.Equal(t, "remote.host", n.Map["RemoteHost"])
 			assert.Equal(t, "SELECT * FROM TEST_TABLE", n.Map["Query"])
 			assert.Equal(t, "MySQL", n.Map["Flavor"])
-
+			assert.NotNil(t, n.Map[ao.KeyBackTrace])
 		}},
 		{"querySpan", "exit"}: {Edges: g.Edges{{"querySpan", "entry"}}},
 		{"myExample", "exit"}: {Edges: g.Edges{{"redis", "exit"}, {"myServiceClient", "exit"}, {"querySpan", "exit"}, {"myExample", "entry"}}},

--- a/v1/ao/doc_test.go
+++ b/v1/ao/doc_test.go
@@ -7,11 +7,12 @@ import (
 	"errors"
 	"testing"
 
+	"context"
+
 	"github.com/appoptics/appoptics-apm-go/v1/ao"
 	g "github.com/appoptics/appoptics-apm-go/v1/ao/internal/graphtest"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
 	"github.com/stretchr/testify/assert"
-	"context"
 )
 
 func testDocSpanExample() {

--- a/v1/ao/http_client_instrumentation.go
+++ b/v1/ao/http_client_instrumentation.go
@@ -41,9 +41,9 @@ func (l HTTPClientSpan) AddHTTPResponse(resp *http.Response, err error) {
 			l.Err(err)
 		}
 		if resp != nil {
-			l.AddEndArgs("RemoteStatus", resp.StatusCode, "ContentLength", resp.ContentLength)
+			l.AddEndArgs(keyRemoteStatus, resp.StatusCode, keyContentLength, resp.ContentLength)
 			if md := resp.Header.Get(HTTPHeaderName); md != "" {
-				l.AddEndArgs("Edge", md)
+				l.AddEndArgs(keyEdge, md)
 			}
 		}
 	}

--- a/v1/ao/http_instrumentation.go
+++ b/v1/ao/http_instrumentation.go
@@ -115,7 +115,7 @@ func (w *HTTPResponseWriter) WriteHeader(status int) {
 	if w.t.IsReporting() {               // set trace exit metadata in X-Trace header
 		// if downstream response headers mention a different span, add edge to it
 		if md != "" && md != w.t.ExitMetadata() {
-			w.t.AddEndArgs("Edge", md)
+			w.t.AddEndArgs(keyEdge, md)
 		}
 		w.Header().Set(HTTPHeaderName, w.t.ExitMetadata()) // replace downstream MD with ours
 	}
@@ -127,7 +127,7 @@ func (w *HTTPResponseWriter) WriteHeader(status int) {
 // wrapped http.ResponseWriter and a pointer to an int containing the status.
 func newResponseWriter(writer http.ResponseWriter, t Trace) *HTTPResponseWriter {
 	w := &HTTPResponseWriter{Writer: writer, t: t, StatusCode: http.StatusOK}
-	t.AddEndArgs("Status", &w.StatusCode)
+	t.AddEndArgs(keyStatus, &w.StatusCode)
 	// add exit event metadata to X-Trace header
 	if t.IsReporting() {
 		// add/replace response header metadata with this trace's
@@ -142,11 +142,11 @@ func traceFromHTTPRequest(spanName string, r *http.Request, isNewcontext bool) T
 	// start trace, passing in metadata header
 	t := NewTraceFromID(spanName, r.Header.Get(HTTPHeaderName), func() KVMap {
 		return KVMap{
-			"Method":       r.Method,
-			"HTTP-Host":    r.Host,
-			"URL":          r.URL.EscapedPath(),
-			"Remote-Host":  r.RemoteAddr,
-			"Query-String": r.URL.RawQuery,
+			keyMethod:      r.Method,
+			keyHTTPHost:    r.Host,
+			keyURL:         r.URL.EscapedPath(),
+			keyRemoteHost:  r.RemoteAddr,
+			keyQueryString: r.URL.RawQuery,
 		}
 	})
 	// set the start time and method for metrics collection

--- a/v1/ao/http_instrumentation.go
+++ b/v1/ao/http_instrumentation.go
@@ -72,15 +72,15 @@ func HTTPHandler(handler func(http.ResponseWriter, *http.Request)) func(http.Res
 func TraceFromHTTPRequestResponse(spanName string, w http.ResponseWriter, r *http.Request) (Trace, http.ResponseWriter,
 	*http.Request) {
 
-	// determine if this is a new context, if so set flag isNewcontext to start a new HTTP Span
-	isNewcontext := false
+	// determine if this is a new context, if so set flag isNewContext to start a new HTTP Span
+	isNewContext := false
 	if b, ok := r.Context().Value(httpSpanKey).(bool); !ok || !b {
 		// save KV to ensure future calls won't treat as new context
 		r = r.WithContext(context.WithValue(r.Context(), httpSpanKey, true))
-		isNewcontext = true
+		isNewContext = true
 	}
 
-	t := traceFromHTTPRequest(spanName, r, isNewcontext)
+	t := traceFromHTTPRequest(spanName, r, isNewContext)
 
 	// Associate the trace with http.Request to expose it to the handler
 	r = r.WithContext(NewContext(r.Context(), t))
@@ -138,7 +138,7 @@ func newResponseWriter(writer http.ResponseWriter, t Trace) *HTTPResponseWriter 
 
 // traceFromHTTPRequest returns a Trace, given an http.Request. If a distributed trace is described
 // in the "X-Trace" header, this context will be continued.
-func traceFromHTTPRequest(spanName string, r *http.Request, isNewcontext bool) Trace {
+func traceFromHTTPRequest(spanName string, r *http.Request, isNewContext bool) Trace {
 	// start trace, passing in metadata header
 	t := NewTraceFromID(spanName, r.Header.Get(HTTPHeaderName), func() KVMap {
 		return KVMap{
@@ -160,7 +160,7 @@ func traceFromHTTPRequest(spanName string, r *http.Request, isNewcontext bool) T
 	t.SetHost(host)
 
 	// Clear the start time if it is not a new context
-	if !isNewcontext {
+	if !isNewContext {
 		t.SetStartTime(time.Time{})
 	}
 	// update incoming metadata in request headers for any downstream readers

--- a/v1/ao/http_instrumentation_test.go
+++ b/v1/ao/http_instrumentation_test.go
@@ -189,7 +189,7 @@ func TestHTTPSpan(t *testing.T) {
 	assert.False(t, m.HasError)
 	assert.InDelta(t, (25*time.Millisecond + nullDuration).Seconds(),
 		m.Duration.Seconds(), (10 * time.Millisecond).Seconds(),
-		nullDuration, fmt.Sprintf("%v", m.Duration))
+		fmt.Sprintf("%v, %v", nullDuration, m.Duration))
 
 	m, ok = r.SpanMessages[3].(*reporter.HTTPSpanMessage)
 	assert.True(t, ok)

--- a/v1/ao/internal/reporter/metrics.go
+++ b/v1/ao/internal/reporter/metrics.go
@@ -24,8 +24,8 @@ const (
 	metricsTransactionsMaxDefault = 200 // default max amount of transaction names we allow per cycle
 	metricsHistPrecisionDefault   = 2   // default histogram precision
 
-	metricsTagNameLenghtMax  = 64  // max number of characters for tag names
-	metricsTagValueLenghtMax = 255 // max number of characters for tag values
+	metricsTagNameLengthMax  = 64  // max number of characters for tag names
+	metricsTagValueLengthMax = 255 // max number of characters for tag values
 )
 
 // Special transaction names
@@ -555,11 +555,11 @@ func addMeasurementToBSON(bbuf *bsonBuffer, index *int, m *Measurement) {
 	if len(m.Tags) > 0 {
 		start := bsonAppendStartObject(bbuf, "tags")
 		for k, v := range m.Tags {
-			if len(k) > metricsTagNameLenghtMax {
-				k = k[0:metricsTagNameLenghtMax]
+			if len(k) > metricsTagNameLengthMax {
+				k = k[0:metricsTagNameLengthMax]
 			}
-			if len(v) > metricsTagValueLenghtMax {
-				v = v[0:metricsTagValueLenghtMax]
+			if len(v) > metricsTagValueLengthMax {
+				v = v[0:metricsTagValueLengthMax]
 			}
 			bsonAppendString(bbuf, k, v)
 		}
@@ -591,11 +591,11 @@ func addHistogramToBSON(bbuf *bsonBuffer, index *int, h *histogram) {
 	if len(h.tags) > 0 {
 		start := bsonAppendStartObject(bbuf, "tags")
 		for k, v := range h.tags {
-			if len(k) > metricsTagNameLenghtMax {
-				k = k[0:metricsTagNameLenghtMax]
+			if len(k) > metricsTagNameLengthMax {
+				k = k[0:metricsTagNameLengthMax]
 			}
-			if len(v) > metricsTagValueLenghtMax {
-				v = v[0:metricsTagValueLenghtMax]
+			if len(v) > metricsTagValueLengthMax {
+				v = v[0:metricsTagValueLengthMax]
 			}
 			bsonAppendString(bbuf, k, v)
 		}

--- a/v1/ao/layer.go
+++ b/v1/ao/layer.go
@@ -38,6 +38,10 @@ type Span interface {
 
 	// Info reports KV pairs provided by args for this Span.
 	Info(args ...interface{})
+
+	// InfoWithOptions reports a new info event with the KVs and options provided
+	InfoWithOptions(opts SpanOptions, args ...interface{})
+
 	// Error reports details about an error (along with a stack trace) for this Span.
 	Error(class, msg string)
 	// Err reports details about error err (along with a stack trace) for this Span.
@@ -186,8 +190,14 @@ func (s *layerSpan) AddEndArgs(args ...interface{}) {
 
 // Info reports KV pairs provided by args.
 func (s *layerSpan) Info(args ...interface{}) {
+	s.InfoWithOptions(SpanOptions{}, args...)
+}
+
+// InfoWithOptions reports a new info event with the KVs and options provided
+func (s *layerSpan) InfoWithOptions(opts SpanOptions, args ...interface{}) {
 	if s.ok() {
-		_ = s.aoCtx.ReportEvent(reporter.LabelInfo, s.layerName(), args...)
+		kvs := addKVsFromOpts(opts, args...)
+		s.aoCtx.ReportEvent(reporter.LabelInfo, s.layerName(), kvs...)
 	}
 }
 
@@ -276,6 +286,7 @@ func (s nullSpan) AddEndArgs(args ...interface{})                        {}
 func (s nullSpan) Error(class, msg string)                               {}
 func (s nullSpan) Err(err error)                                         {}
 func (s nullSpan) Info(args ...interface{})                              {}
+func (s nullSpan) InfoWithOptions(opts SpanOptions, args ...interface{}) {}
 func (s nullSpan) IsReporting() bool                                     { return false }
 func (s nullSpan) addChildEdge(reporter.Context)                         {}
 func (s nullSpan) addProfile(Profile)                                    {}

--- a/v1/ao/layer.go
+++ b/v1/ao/layer.go
@@ -105,6 +105,20 @@ func addKVsFromOpts(opts SpanOptions, args ...interface{}) []interface{} {
 	return kvs
 }
 
+func fromKVs(kvs ...interface{}) KVMap {
+	m := make(KVMap)
+	for idx, val := range kvs {
+		if idx >= len(kvs)-1 {
+			break
+		}
+		if valStr, ok := val.(string); ok {
+			m[valStr] = kvs[idx+1]
+		}
+		idx += 2
+	}
+	return m
+}
+
 // BeginSpanWithOptions starts a span with provided options
 func BeginSpanWithOptions(ctx context.Context, spanName string, opts SpanOptions, args ...interface{}) (Span, context.Context) {
 	kvs := addKVsFromOpts(opts, args...)

--- a/v1/ao/layer.go
+++ b/v1/ao/layer.go
@@ -133,10 +133,15 @@ func BeginSpan(ctx context.Context, spanName string, args ...interface{}) (Span,
 func addKVsFromOpts(opts SpanOptions, args ...interface{}) []interface{} {
 	kvs := args
 	if opts.WithBackTrace {
-		kvs = make([]interface{}, 0, len(args)+2)
-		kvs = append(kvs, args...)
-		kvs = append(kvs, KeyBackTrace, string(debug.Stack()))
+		kvs = mergeKVs(args, []interface{}{KeyBackTrace, string(debug.Stack())})
 	}
+	return kvs
+}
+
+func mergeKVs(left []interface{}, right []interface{}) []interface{} {
+	kvs := make([]interface{}, 0, len(left)+len(right))
+	kvs = append(kvs, left...)
+	kvs = append(kvs, right...)
 	return kvs
 }
 

--- a/v1/ao/layer.go
+++ b/v1/ao/layer.go
@@ -124,6 +124,16 @@ type SpanOptions struct {
 	WithBackTrace bool
 }
 
+// SpanOpt defines the function type that changes the SpanOptions
+type SpanOpt func(*SpanOptions)
+
+// WithBackTrace returns a function that sets the WithBackTrace flag
+func WithBackTrace() SpanOpt {
+	return func(o *SpanOptions) {
+		o.WithBackTrace = true
+	}
+}
+
 // BeginSpan starts a new Span, provided a parent context and name. It returns a Span
 // and context bound to the new child Span.
 func BeginSpan(ctx context.Context, spanName string, args ...interface{}) (Span, context.Context) {

--- a/v1/ao/layer.go
+++ b/v1/ao/layer.go
@@ -121,6 +121,9 @@ type Profile interface {
 // SpanOptions defines the options of creating a span
 type SpanOptions struct {
 	// WithBackTrace indicates whether to include the backtrace in BeginSpan
+	// Keep in mind that the cost of this option may be high as it calls
+	// `debug.Stack()` internally to gather the stack trace. Please consider
+	// the impact on performance/memory footprint carefully.
 	WithBackTrace bool
 }
 
@@ -140,6 +143,7 @@ func BeginSpan(ctx context.Context, spanName string, args ...interface{}) (Span,
 	return BeginSpanWithOptions(ctx, spanName, SpanOptions{}, args...)
 }
 
+// addKVsFromOpts adds the KVs correspond to the options to the args
 func addKVsFromOpts(opts SpanOptions, args ...interface{}) []interface{} {
 	kvs := args
 	if opts.WithBackTrace {
@@ -148,6 +152,8 @@ func addKVsFromOpts(opts SpanOptions, args ...interface{}) []interface{} {
 	return kvs
 }
 
+// mergeKVs merges two slices into a single one. An empty slice instead of
+// nil will be returned if both of the arguments are nil.
 func mergeKVs(left []interface{}, right []interface{}) []interface{} {
 	kvs := make([]interface{}, 0, len(left)+len(right))
 	kvs = append(kvs, left...)
@@ -155,6 +161,8 @@ func mergeKVs(left []interface{}, right []interface{}) []interface{} {
 	return kvs
 }
 
+// fromKVs converts a slice of Key-Value pairs to a KVMap.
+// The dangling element of the slice will be dropped.
 func fromKVs(kvs ...interface{}) KVMap {
 	m := make(KVMap)
 	for idx, val := range kvs {

--- a/v1/ao/layer.go
+++ b/v1/ao/layer.go
@@ -5,6 +5,7 @@ package ao
 import (
 	"context"
 	"errors"
+	"fmt"
 	"runtime"
 	"runtime/debug"
 	"sync"
@@ -258,6 +259,7 @@ func (s *layerSpan) MetadataString() string {
 	return ""
 }
 
+// IsSampled indicates if the layer is sampled.
 func (s *layerSpan) IsSampled() bool {
 	if s.ok() {
 		return s.aoCtx.IsSampled()
@@ -280,14 +282,19 @@ func (s *span) SetOperationName(name string) {
 // SetTransactionName sets the transaction name used to categorize service requests in AppOptics.
 func (s *span) SetTransactionName(name string) error {
 	if !s.ok() {
-		return errors.New("failed to set custom transaction name, invalid span")
+		return errEndedSpan
 	}
 	if name == "" || len(name) > MaxCustomTransactionNameLength {
-		return errors.New("valid length for custom transaction name: 1~255")
+		return errTransactionNameLength
 	}
 	s.aoCtx.SetTransactionName(name)
 	return nil
 }
+
+var (
+	errEndedSpan             = errors.New("span is ended")
+	errTransactionNameLength = fmt.Errorf("name must not be longer than %d", MaxCustomTransactionNameLength)
+)
 
 // GetTransactionName returns the current value of the transaction name
 func (s *span) GetTransactionName() string {

--- a/v1/ao/layer_test.go
+++ b/v1/ao/layer_test.go
@@ -33,10 +33,10 @@ func TestErrorSpec(t *testing.T) {
 		assert.Equal(t, "testMsg", m["ErrorMsg"])
 		assert.Contains(t, m, "Timestamp_u")
 		assert.Contains(t, m, "X-Trace")
-		assert.Contains(t, m, "Backtrace")
+		assert.Contains(t, m, KeyBackTrace)
 		assert.Equal(t, "1", m["_V"])
 		assert.Equal(t, "testClass", m["ErrorClass"])
-		assert.IsType(t, "", m["Backtrace"])
+		assert.IsType(t, "", m[KeyBackTrace])
 	}
 	assert.True(t, foundErrEvt)
 }
@@ -65,11 +65,11 @@ func TestBeginSpan(t *testing.T) {
 		layer := m["Layer"]
 		switch layer {
 		case "testSpan":
-			assert.Nil(t, m["Backtrace"], layer)
+			assert.Nil(t, m[KeyBackTrace], layer)
 		case "spanWithBackTrace":
-			assert.NotNil(t, m["Backtrace"], layer)
+			assert.NotNil(t, m[KeyBackTrace], layer)
 		case "spanWithBackTrace2":
-			assert.NotNil(t, m["Backtrace"], layer)
+			assert.NotNil(t, m[KeyBackTrace], layer)
 		}
 	}
 }
@@ -96,7 +96,7 @@ func TestSpanInfo(t *testing.T) {
 		layer := m["Layer"]
 		switch layer {
 		case "testSpan":
-			assert.NotNil(t, m["Backtrace"], layer)
+			assert.NotNil(t, m[KeyBackTrace], layer)
 		}
 	}
 }

--- a/v1/ao/layer_test.go
+++ b/v1/ao/layer_test.go
@@ -2,6 +2,7 @@ package ao
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
@@ -147,4 +148,22 @@ func TestAddKVsFromOpts(t *testing.T) {
 
 	kvs = addKVsFromOpts(SpanOptions{WithBackTrace: true}, "hello", 1)
 	assert.Equal(t, 4, len(kvs))
+}
+
+func TestMergeKVs(t *testing.T) {
+	cases := []struct {
+		left   []interface{}
+		right  []interface{}
+		merged []interface{}
+	}{
+		{[]interface{}{}, []interface{}{}, []interface{}{}},
+		{[]interface{}{"a"}, []interface{}{}, []interface{}{"a"}},
+		{[]interface{}{}, []interface{}{"a"}, []interface{}{"a"}},
+		{[]interface{}{"a"}, []interface{}{"b"}, []interface{}{"a", "b"}},
+		{[]interface{}{"a", "b"}, []interface{}{"c", "d"}, []interface{}{"a", "b", "c", "d"}},
+	}
+
+	for idx, c := range cases {
+		assert.Equal(t, c.merged, mergeKVs(c.left, c.right), fmt.Sprintf("Test case: #%d", idx))
+	}
 }

--- a/v1/ao/layer_test.go
+++ b/v1/ao/layer_test.go
@@ -2,7 +2,6 @@ package ao
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
@@ -49,12 +48,13 @@ func TestBeginSpan(t *testing.T) {
 	s, _ := BeginSpan(ctx, "testSpan")
 
 	subSpan, _ := BeginSpanWithOptions(ctx, "spanWithBackTrace", SpanOptions{WithBackTrace: true})
+	subSpan.BeginSpanWithOptions("spanWithBackTrace", SpanOptions{WithBackTrace: true}).End()
 	subSpan.End()
 
 	s.End()
 	EndTrace(ctx)
 
-	r.Close(6)
+	r.Close(8)
 
 	for _, evt := range r.EventBufs {
 		m := make(map[string]interface{})
@@ -68,8 +68,8 @@ func TestBeginSpan(t *testing.T) {
 			assert.Nil(t, m["Backtrace"], layer)
 		case "spanWithBackTrace":
 			assert.NotNil(t, m["Backtrace"], layer)
+		case "spanWithBackTrace2":
+			assert.NotNil(t, m["Backtrace"], layer)
 		}
-		// TODO: remove it
-		fmt.Println(m)
 	}
 }

--- a/v1/ao/layer_test.go
+++ b/v1/ao/layer_test.go
@@ -156,6 +156,9 @@ func TestMergeKVs(t *testing.T) {
 		right  []interface{}
 		merged []interface{}
 	}{
+		{nil, nil, []interface{}{}},
+		{nil, []interface{}{}, []interface{}{}},
+		{[]interface{}{}, nil, []interface{}{}},
 		{[]interface{}{}, []interface{}{}, []interface{}{}},
 		{[]interface{}{"a"}, []interface{}{}, []interface{}{"a"}},
 		{[]interface{}{}, []interface{}{"a"}, []interface{}{"a"}},

--- a/v1/ao/layer_test.go
+++ b/v1/ao/layer_test.go
@@ -100,3 +100,51 @@ func TestSpanInfo(t *testing.T) {
 		}
 	}
 }
+
+func TestFromKVs(t *testing.T) {
+	assert.Equal(t, 0, len(fromKVs()))
+	assert.Equal(t, 0, len(fromKVs("hello")))
+	m := fromKVs("hello", 1)
+	assert.Equal(t, 1, len(m))
+	assert.Equal(t, 1, m["hello"])
+
+	m = fromKVs("hello", 1, 2)
+	assert.Equal(t, 1, len(m))
+	assert.Equal(t, 1, m["hello"])
+
+	m = fromKVs("hello", 1, "world", 2)
+	assert.Equal(t, 2, len(m))
+	assert.Equal(t, 1, m["hello"])
+	assert.Equal(t, 2, m["world"])
+
+	m = fromKVs(1, 1, 2)
+	assert.Equal(t, 0, len(m))
+
+	m = fromKVs(nil, "hello", 1)
+	assert.Equal(t, 1, len(m))
+	assert.Equal(t, 1, m["hello"])
+
+	m = fromKVs(1.1, "hello", 1)
+	assert.Equal(t, 1, len(m))
+	assert.Equal(t, 1, m["hello"])
+
+	m = fromKVs([]string{"1", "2"}, "hello", 1)
+	assert.Equal(t, 1, len(m))
+	assert.Equal(t, 1, m["hello"])
+}
+
+func TestAddKVsFromOpts(t *testing.T) {
+	assert.Equal(t, 0, len(addKVsFromOpts(SpanOptions{})))
+
+	kvs := addKVsFromOpts(SpanOptions{}, "hello")
+	assert.Equal(t, []interface{}{"hello"}, kvs)
+
+	kvs = addKVsFromOpts(SpanOptions{}, "hello", 1)
+	assert.Equal(t, []interface{}{"hello", 1}, kvs)
+
+	kvs = addKVsFromOpts(SpanOptions{WithBackTrace: true})
+	assert.Equal(t, 2, len(kvs))
+
+	kvs = addKVsFromOpts(SpanOptions{WithBackTrace: true}, "hello", 1)
+	assert.Equal(t, 4, len(kvs))
+}

--- a/v1/ao/profile_test.go
+++ b/v1/ao/profile_test.go
@@ -5,11 +5,12 @@ package ao_test
 import (
 	"testing"
 
+	"context"
+
 	"github.com/appoptics/appoptics-apm-go/v1/ao"
 	g "github.com/appoptics/appoptics-apm-go/v1/ao/internal/graphtest"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
 	"github.com/stretchr/testify/assert"
-	"context"
 )
 
 func testProf(ctx context.Context) {

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -17,18 +17,18 @@ import (
 // methods that can be used to help categorize a service's inbound requests on the
 // AppOptics service dashboard.
 type Trace interface {
-	// Inherited from the Span interface
-	//  BeginSpan(spanName string, args ...interface{}) Span
-	//  BeginProfile(profileName string, args ...interface{}) Profile
-	// 	End(args ...interface{})
-	// 	Info(args ...interface{})
-	//  Error(class, msg string)
-	//  Err(error)
-	//  IsSampled() bool
+	// Span inherited from the Span interface
+	// BeginSpan(spanName string, args ...interface{}) Span
+	// BeginProfile(profileName string, args ...interface{}) Profile
+	// End(args ...interface{})
+	// Info(args ...interface{})
+	// Error(class, msg string)
+	// Err(error)
+	// IsSampled() bool
 	Span
 
-	// End a Trace, and include KV pairs returned by func f. Useful
-	// alternative to End() when used with defer to delay evaluation
+	// EndCallback ends a trace, and include KV pairs returned by func f.
+	// Useful alternative to End() when used with defer to delay evaluation
 	// of KVs until the end of the trace (since a deferred function's
 	// arguments are evaluated when the defer statement is
 	// evaluated). Func f will not be called at all if this span is

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -88,20 +88,6 @@ func NewTrace(spanName string) Trace {
 	return NewTraceFromID(spanName, "", nil)
 }
 
-func fromKVs(kvs ...interface{}) KVMap {
-	m := make(KVMap)
-	for idx, val := range kvs {
-		if idx >= len(kvs)-1 {
-			break
-		}
-		if valStr, ok := val.(string); ok {
-			m[valStr] = kvs[idx+1]
-		}
-		idx += 2
-	}
-	return m
-}
-
 // NewTraceWithOptions creates a new trace with the provided options
 func NewTraceWithOptions(spanName string, opts SpanOptions) Trace {
 	kvs := addKVsFromOpts(opts)

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -99,12 +99,12 @@ func NewTraceWithOptions(spanName string, opts SpanOptions) Trace {
 // NewTraceFromID creates a new Trace for reporting to AppOptics, provided an
 // incoming trace ID (e.g. from a incoming RPC or service call's "X-Trace" header).
 // If callback is provided & trace is sampled, cb will be called for entry event KVs
-func NewTraceFromID(spanName, mdstr string, cb func() KVMap) Trace {
+func NewTraceFromID(spanName, mdStr string, cb func() KVMap) Trace {
 	if Disabled() || Closed() {
 		return NewNullTrace()
 	}
 
-	ctx, ok := reporter.NewContext(spanName, mdstr, true, func() map[string]interface{} {
+	ctx, ok := reporter.NewContext(spanName, mdStr, true, func() map[string]interface{} {
 		if cb != nil {
 			return cb()
 		}

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -88,6 +88,28 @@ func NewTrace(spanName string) Trace {
 	return NewTraceFromID(spanName, "", nil)
 }
 
+func fromKVs(kvs ...interface{}) KVMap {
+	m := make(KVMap)
+	for idx, val := range kvs {
+		if idx >= len(kvs)-1 {
+			break
+		}
+		if valStr, ok := val.(string); ok {
+			m[valStr] = kvs[idx+1]
+		}
+		idx += 2
+	}
+	return m
+}
+
+// NewTraceWithOptions creates a new trace with the provided options
+func NewTraceWithOptions(spanName string, opts SpanOptions) Trace {
+	kvs := addKVsFromOpts(opts)
+	return NewTraceFromID(spanName, "", func() KVMap {
+		return fromKVs(kvs...)
+	})
+}
+
 // NewTraceFromID creates a new Trace for reporting to AppOptics, provided an
 // incoming trace ID (e.g. from a incoming RPC or service call's "X-Trace" header).
 // If callback is provided & trace is sampled, cb will be called for entry event KVs

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -85,19 +85,7 @@ func (t *aoTrace) aoContext() reporter.Context { return t.aoCtx }
 // the beginning of a root span named spanName. If this trace is sampled, it may report
 // event data to AppOptics; otherwise event reporting will be a no-op.
 func NewTrace(spanName string) Trace {
-	if Disabled() || Closed() {
-		return NewNullTrace()
-	}
-
-	ctx, ok := reporter.NewContext(spanName, "", true, nil)
-	if !ok {
-		return NewNullTrace()
-	}
-	t := &aoTrace{
-		layerSpan: layerSpan{span: span{aoCtx: ctx, labeler: spanLabeler{spanName}}},
-	}
-	t.SetStartTime(time.Now())
-	return t
+	return NewTraceFromID(spanName, "", nil)
 }
 
 // NewTraceFromID creates a new Trace for reporting to AppOptics, provided an

--- a/v1/ao/trace_test.go
+++ b/v1/ao/trace_test.go
@@ -364,10 +364,10 @@ func TestTraceWithOptions(t *testing.T) {
 		// entry event should have no edges
 		{"test", "entry"}: {},
 		{"test", "exit"}: {Edges: g.Edges{{"test", "entry"}}, Callback: func(n g.Node) {
-			assert.Nil(t, n.Map["Backtrace"])
+			assert.Nil(t, n.Map[ao.KeyBackTrace])
 		}},
 		{"testWithBacktrace", "entry"}: {Callback: func(n g.Node) {
-			assert.NotNil(t, n.Map["Backtrace"])
+			assert.NotNil(t, n.Map[ao.KeyBackTrace])
 		}},
 		{"testWithBacktrace", "exit"}: {Edges: g.Edges{{"testWithBacktrace", "entry"}}},
 	})


### PR DESCRIPTION
Jira ticket: https://swicloud.atlassian.net/browse/AO-10162

The changes:
- add stacktrace in BeginSpan
- add stacktrace in Info
- add stacktrace in NewTrace / NewTraceFromID
- client spans (query, cache, rpc, etc)
- open to future extensions without breaking the old APIs