### PR TITLE
AO-7047: add Spec KV to RPC/HTTP/Cache event

### DIFF
--- a/v1/ao/client_layer.go
+++ b/v1/ao/client_layer.go
@@ -44,10 +44,17 @@ func BeginRemoteURLSpan(ctx context.Context, spanName, remoteURL string, args ..
 // BeginRPCSpan returns a Span that reports metadata used by AppOptics to filter RPC call
 // latency heatmaps and charts by span name, protocol, controller, and remote host.
 // Call or defer the returned Span's End() to time the call's client-side latency.
-func BeginRPCSpan(ctx context.Context, spanName, protocol, controller, remoteHost string, args ...interface{}) Span {
-	rsKVs := []interface{}{"IsService", true,
-		"RemoteProtocol", protocol, "RemoteHost", remoteHost, "RemoteController", controller}
+func BeginRPCSpan(ctx context.Context, spanName, protocol, controller, remoteHost string,
+	args ...interface{}) Span {
+	rsKVs := []interface{}{
+		"Spec", "rsc",
+		"IsService", true,
+		"RemoteProtocol", protocol,
+		"RemoteHost", remoteHost,
+		"RemoteController", controller}
+
 	kvs := mergeKVs(rsKVs, args)
 	l, _ := BeginSpan(ctx, spanName, kvs...)
+
 	return l
 }

--- a/v1/ao/client_layer.go
+++ b/v1/ao/client_layer.go
@@ -23,7 +23,7 @@ func BeginQuerySpan(ctx context.Context, spanName, query, flavor, remoteHost str
 // Optional parameter "key" will display in the trace's details, but will not be indexed.
 // Call or defer the returned Span's End() to time the request's client-side latency.
 func BeginCacheSpan(ctx context.Context, spanName, op, key, remoteHost string, hit bool, args ...interface{}) Span {
-	csKVs := []interface{}{"KVOp", op, "KVKey", key, "KVHit", hit, "RemoteHost", remoteHost}
+	csKVs := []interface{}{"Spec", "cache", "KVOp", op, "KVKey", key, "KVHit", hit, "RemoteHost", remoteHost}
 	kvs := mergeKVs(csKVs, args)
 	l, _ := BeginSpan(ctx, spanName, kvs...)
 	return l
@@ -35,7 +35,7 @@ func BeginCacheSpan(ctx context.Context, spanName, op, key, remoteHost string, h
 // metadata headers via http.Request and http.Response.
 // Call or defer the returned Span's End() to time the call's client-side latency.
 func BeginRemoteURLSpan(ctx context.Context, spanName, remoteURL string, args ...interface{}) Span {
-	rsKVs := []interface{}{"IsService", true, "RemoteURL", remoteURL}
+	rsKVs := []interface{}{"Spec", "rsc", "IsService", true, "RemoteURL", remoteURL}
 	kvs := mergeKVs(rsKVs, args)
 	l, _ := BeginSpan(ctx, spanName, kvs...)
 	return l

--- a/v1/ao/client_layer_test.go
+++ b/v1/ao/client_layer_test.go
@@ -59,6 +59,7 @@ func TestSpans(t *testing.T) {
 			assert.Equal(t, "service.net", n.Map["RemoteHost"])
 			assert.Equal(t, "incrKey", n.Map["RemoteController"])
 			assert.Equal(t, "thrift", n.Map["RemoteProtocol"])
+			assert.Equal(t, "rsc", n.Map["Spec"])
 		}},
 		{"myServiceClient", "exit"}: {Edges: g.Edges{{"myServiceClient", "entry"}}},
 		{"querySpan", "entry"}: {Edges: g.Edges{{"myExample", "entry"}}, Callback: func(n g.Node) {


### PR DESCRIPTION
Add a new KV `Spec`=`rsc` to the RPC/HTTP/Cache Span event. This follows the Remote Service Call spec in https://github.com/librato/trace/blob/master/docs/specs/KV/remote-service-call.md#remote-service-call

See also: https://swicloud.atlassian.net/browse/AO-7047