### PR TITLE
Optimize TraceFromContext when context is empty

### DIFF
--- a/v1/ao/context.go
+++ b/v1/ao/context.go
@@ -4,7 +4,7 @@ package ao
 
 import "context"
 
-type contextKeyT string
+type contextKeyT interface{}
 
 var contextKey = contextKeyT("github.com/appoptics/appoptics-apm-go/v1/ao.Trace")
 var contextSpanKey = contextKeyT("github.com/appoptics/appoptics-apm-go/v1/ao.Span")

--- a/v1/ao/context_test.go
+++ b/v1/ao/context_test.go
@@ -3,13 +3,13 @@
 package ao
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
 	g "github.com/appoptics/appoptics-apm-go/v1/ao/internal/graphtest"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
 	"github.com/stretchr/testify/assert"
-	"context"
 )
 
 func TestContext(t *testing.T) {
@@ -104,4 +104,12 @@ func TestNullSpan(t *testing.T) {
 		{"L1", "entry"}:           {Edges: g.Edges{{"TestNullSpan", "entry"}}},
 		{"L1", "exit"}:            {Edges: g.Edges{{"L1", "entry"}}},
 	})
+}
+
+func BenchmarkTraceFromContextEmpty(b *testing.B) {
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		TraceFromContext(ctx)
+	}
 }

--- a/v1/ao/http_instrumentation.go
+++ b/v1/ao/http_instrumentation.go
@@ -21,7 +21,7 @@ const HTTPHeaderName = "X-Trace"
 const httpHandlerSpanName = "http.HandlerFunc"
 
 // key used for HTTP span to indicate a new context
-const httpSpanKey = contextKeyT("github.com/appoptics/appoptics-apm-go/v1/ao.HTTPSpan")
+var httpSpanKey = contextKeyT("github.com/appoptics/appoptics-apm-go/v1/ao.HTTPSpan")
 
 // HTTPHandler wraps an http.HandlerFunc with entry / exit events,
 // returning a new handler that can be used in its place.


### PR DESCRIPTION
While benchmarking code that happened to invoke this library's TraceFromContext function I discovered that TraceFromContext was strangely allocating a single object on the heap in every invocation.

I added a benchmark and dug into it. `context.Value(...)` takes an `interface{}` type argument, and it seems that in order to pass `contextSpanKey` (which is in turn `type contextKeyT string`) as `interface{}`, a new interface is allocated on the heap.

Benchmark before:

```
$ go test -benchmem -bench BenchmarkTraceFromContextEmpty
...
BenchmarkTraceFromContextEmpty-12    	50000000	        34.6 ns/op	      16 B/op	       1 allocs/op
```

If we change `type contextKeyT string` to `type contextKeyT interface{}`, we can avoid this heap allocation:

```
$ go test -benchmem -bench BenchmarkTraceFromContextEmpty
BenchmarkTraceFromContextEmpty-12    	200000000	         9.50 ns/op	       0 B/op	       0 allocs/op
```