### PR TITLE
AO-12194: Fix distro info in metrics messages

### DIFF
--- a/v1/ao/internal/host/host.go
+++ b/v1/ao/internal/host/host.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	REDHAT    = "/etc/redhat-release"
-	AMAZON    = "/etc/release-cpe"
+	AMAZON    = "/etc/system-release"
 	UBUNTU    = "/etc/lsb-release"
 	DEBIAN    = "/etc/debian_version"
 	SUSE      = "/etc/SuSE-release"

--- a/v1/ao/internal/host/sys_linux.go
+++ b/v1/ao/internal/host/sys_linux.go
@@ -61,8 +61,11 @@ func initDistro() (distro string) {
 	pathes := []string{DEBIAN, SUSE, SLACKWARE, GENTOO, OTHER}
 	if path, line := utils.GetStrByKeywordFiles(pathes, ""); path != "" && line != "" {
 		distro = line
-		if path == "Debian" {
+		if path == DEBIAN {
 			distro = "Debian " + distro
+		}
+		if idx := strings.Index(distro, "Alpine"); idx != -1 {
+			distro = distro[idx:]
 		}
 	} else {
 		distro = "Unknown"

--- a/v1/ao/internal/host/sys_linux.go
+++ b/v1/ao/internal/host/sys_linux.go
@@ -38,17 +38,13 @@ func initDistro() (distro string) {
 	}
 	// amazon linux
 	distro = utils.GetStrByKeyword(AMAZON, "")
-
-	ds := strings.Split(distro, ":")
-	distro = ds[len(ds)-1]
 	if distro != "" {
-		distro = "Amzn Linux " + distro
 		return distro
 	}
 	// ubuntu
 	distro = utils.GetStrByKeyword(UBUNTU, "DISTRIB_DESCRIPTION")
 	if distro != "" {
-		ds = strings.Split(distro, "=")
+		ds := strings.Split(distro, "=")
 		distro = ds[len(ds)-1]
 		if distro != "" {
 			distro = strings.Trim(distro, "\"")


### PR DESCRIPTION
The test results:

distro_1  | Distro is: Ubuntu 18.04.2 LTS
distro_1  | Distro is: Alpine Linux 3.9
distro_1  | Distro is: openSUSE Leap 15.0
distro_1  | Distro is: Debian GNU/Linux 8 (jessie)
distro_1  | Distro is: Amazon Linux release 2 (Karoo)
distro_1  | Distro is: Red Hat Enterprise Linux Server release 7.6 (Maipo)  _(with oraclelinux image)_