### PR TITLE
AO-12116: [transaction setting] Rename transaction filtering settings

### DIFF
--- a/v1/ao/internal/config/config.go
+++ b/v1/ao/internal/config/config.go
@@ -103,7 +103,7 @@ type Config struct {
 	ReporterProperties *ReporterOptions `yaml:"ReporterProperties,omitempty"`
 
 	// The transaction filtering config
-	TransactionFiltering []TransactionFilter `yaml:"TransactionFiltering,omitempty"`
+	TransactionSettings []TransactionFilter `yaml:"TransactionSettings,omitempty"`
 
 	Disabled bool `yaml:"Disabled,omitempty" env:"APPOPTICS_DISABLED"`
 
@@ -782,5 +782,5 @@ func (c *Config) GetDebugLevel() string {
 func (c *Config) GetTransactionFiltering() []TransactionFilter {
 	c.RLock()
 	defer c.RUnlock()
-	return c.TransactionFiltering
+	return c.TransactionSettings
 }

--- a/v1/ao/internal/config/config_test.go
+++ b/v1/ao/internal/config/config_test.go
@@ -250,7 +250,7 @@ func TestYamlConfig(t *testing.T) {
 			RetryLogThreshold:       10,
 			MaxRetries:              20,
 		},
-		TransactionFiltering: []TransactionFilter{
+		TransactionSettings: []TransactionFilter{
 			{"url", `\s+\d+\s+`, nil, "disabled"},
 			{"url", "", []string{".jpg"}, "disabled"},
 		},
@@ -321,7 +321,7 @@ func TestYamlConfig(t *testing.T) {
 			RetryLogThreshold:       10,
 			MaxRetries:              20,
 		},
-		TransactionFiltering: []TransactionFilter{
+		TransactionSettings: []TransactionFilter{
 			{"url", `\s+\d+\s+`, nil, "disabled"},
 			{"url", "", []string{".jpg"}, "disabled"},
 		},

--- a/v1/ao/internal/utils/version.go
+++ b/v1/ao/internal/utils/version.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	// The AppOptics Go agent version
-	version = "1.6.0"
+	version = "1.6.1"
 
 	// The Go version
 	goVersion = strings.TrimPrefix(runtime.Version(), "go")


### PR DESCRIPTION
- Rename the transaction filtering setting name to keep it consistent among all language agents.
- Update version number to v1.6.1