### PR TITLE
AO-12331: Manual Log Injection

### DIFF
--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -12,6 +12,11 @@ import (
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
 )
 
+const (
+	// LoggableTraceID is used as the key for log injection.
+	LoggableTraceID = "ao.traceId"
+)
+
 // Trace represents the root span of a distributed trace for this request that reports
 // events to AppOptics. The Trace interface extends the Span interface with additional
 // methods that can be used to help categorize a service's inbound requests on the


### PR DESCRIPTION
This PR adds a new method `LoggableTraceID()` to the `ao.Trace` interface`. It can be used to fetch the loggable trace ID of the trace.

The loggable trace ID is in the following format:
`trace ID` + `-` + `sampled flag (0|1)`