### PR TITLE
AO-7048: SQL sanitization

### DIFF
--- a/v1/ao/client_layer.go
+++ b/v1/ao/client_layer.go
@@ -3,13 +3,18 @@
 
 package ao
 
-import "context"
+import (
+	"context"
+
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
+)
 
 // BeginQuerySpan returns a Span that reports metadata used by AppOptics to filter
 // query latency heatmaps and charts by span name, query statement, DB host and table.
 // Parameter "flavor" specifies the flavor of the query statement, such as "mysql", "postgresql", or "mongodb".
 // Call or defer the returned Span's End() to time the query's client-side latency.
 func BeginQuerySpan(ctx context.Context, spanName, query, flavor, remoteHost string, args ...interface{}) Span {
+	query = reporter.SQLSanitize(query)
 	qsKVs := []interface{}{"Spec", "query", "Query", query, "Flavor", flavor, "RemoteHost", remoteHost}
 	kvs := mergeKVs(qsKVs, args)
 	l, _ := BeginSpan(ctx, spanName, kvs...)

--- a/v1/ao/client_layer.go
+++ b/v1/ao/client_layer.go
@@ -14,7 +14,7 @@ import (
 // Parameter "flavor" specifies the flavor of the query statement, such as "mysql", "postgresql", or "mongodb".
 // Call or defer the returned Span's End() to time the query's client-side latency.
 func BeginQuerySpan(ctx context.Context, spanName, query, flavor, remoteHost string, args ...interface{}) Span {
-	query = reporter.SQLSanitize(query)
+	query = reporter.SQLSanitize(query, flavor)
 	qsKVs := []interface{}{"Spec", "query", "Query", query, "Flavor", flavor, "RemoteHost", remoteHost}
 	kvs := mergeKVs(qsKVs, args)
 	l, _ := BeginSpan(ctx, spanName, kvs...)

--- a/v1/ao/client_layer.go
+++ b/v1/ao/client_layer.go
@@ -14,7 +14,7 @@ import (
 // Parameter "flavor" specifies the flavor of the query statement, such as "mysql", "postgresql", or "mongodb".
 // Call or defer the returned Span's End() to time the query's client-side latency.
 func BeginQuerySpan(ctx context.Context, spanName, query, flavor, remoteHost string, args ...interface{}) Span {
-	query = reporter.SQLSanitize(query, flavor)
+	query = reporter.SQLSanitize(flavor, query)
 	qsKVs := []interface{}{"Spec", "query", "Query", query, "Flavor", flavor, "RemoteHost", remoteHost}
 	kvs := mergeKVs(qsKVs, args)
 	l, _ := BeginSpan(ctx, spanName, kvs...)

--- a/v1/ao/internal/config/config.go
+++ b/v1/ao/internal/config/config.go
@@ -100,7 +100,7 @@ type Config struct {
 	Precision int `yaml:"Precision,omitempty" env:"APPOPTICS_HISTOGRAM_PRECISION" default:"2"`
 
 	// The SQL sanitization level
-	SQLSanitize int `yaml:"SQLSanitize,omitempty" env:"APPOPTICS_SQL_SANITIZE" default:"1"`
+	SQLSanitize int `yaml:"SQLSanitize,omitempty" env:"APPOPTICS_SQL_SANITIZE" default:"0"`
 
 	// The reporter options
 	ReporterProperties *ReporterOptions `yaml:"ReporterProperties,omitempty"`
@@ -791,9 +791,9 @@ func (c *Config) GetTransactionFiltering() []TransactionFilter {
 // GetSQLSanitize returns the SQL sanitization level.
 //
 // The meaning of each level:
-// 0 - disable SQL sanitizing.
+// 0 - disable SQL sanitizing (the default).
 // 1 - enable SQL sanitizing and attempt to automatically determine which
-// quoting form to use (the default).
+// quoting form to use.
 // 2 - enable SQL sanitizing and force dropping double quoted characters.
 // 4 - enable SQL sanitizing and force retaining double quoted character.
 func (c *Config) GetSQLSanitize() int {

--- a/v1/ao/internal/config/config.go
+++ b/v1/ao/internal/config/config.go
@@ -99,6 +99,9 @@ type Config struct {
 	// The precision of the histogram
 	Precision int `yaml:"Precision,omitempty" env:"APPOPTICS_HISTOGRAM_PRECISION" default:"2"`
 
+	// The SQL sanitization level
+	SQLSanitize int `yaml:"SQLSanitize,omitempty" env:"APPOPTICS_SQL_SANITIZE" default:"1"`
+
 	// The reporter options
 	ReporterProperties *ReporterOptions `yaml:"ReporterProperties,omitempty"`
 
@@ -783,4 +786,18 @@ func (c *Config) GetTransactionFiltering() []TransactionFilter {
 	c.RLock()
 	defer c.RUnlock()
 	return c.TransactionSettings
+}
+
+// GetSQLSanitize returns the SQL sanitization level.
+//
+// The meaning of each level:
+// 0 - disable SQL sanitizing.
+// 1 - enable SQL sanitizing and attempt to automatically determine which
+// quoting form to use (the default).
+// 2 - enable SQL sanitizing and force dropping double quoted characters.
+// 4 - enable SQL sanitizing and force retaining double quoted character.
+func (c *Config) GetSQLSanitize() int {
+	c.RLock()
+	defer c.RUnlock()
+	return c.SQLSanitize
 }

--- a/v1/ao/internal/config/config_test.go
+++ b/v1/ao/internal/config/config_test.go
@@ -139,7 +139,7 @@ func TestConfigInit(t *testing.T) {
 			RetryLogThreshold:       10,
 			MaxRetries:              20,
 		},
-		SQLSanitize: 1,
+		SQLSanitize: 0,
 		Disabled:    false,
 		DebugLevel:  "warn",
 	}

--- a/v1/ao/internal/config/config_test.go
+++ b/v1/ao/internal/config/config_test.go
@@ -139,8 +139,9 @@ func TestConfigInit(t *testing.T) {
 			RetryLogThreshold:       10,
 			MaxRetries:              20,
 		},
-		Disabled:   false,
-		DebugLevel: "warn",
+		SQLSanitize: 1,
+		Disabled:    false,
+		DebugLevel:  "warn",
 	}
 	assert.Equal(t, *c, defaultC)
 }
@@ -179,6 +180,7 @@ func TestEnvsLoading(t *testing.T) {
 		"APPOPTICS_EVENTS_FLUSH_INTERVAL=4",
 		"APPOPTICS_EVENTS_BATCHSIZE=4000",
 		"APPOPTICS_DISABLED=true",
+		"APPOPTICS_SQL_SANITIZE=0",
 	}
 	SetEnvs(envs)
 
@@ -211,8 +213,9 @@ func TestEnvsLoading(t *testing.T) {
 			RetryLogThreshold:       10,
 			MaxRetries:              20,
 		},
-		Disabled:   true,
-		DebugLevel: "warn",
+		SQLSanitize: 0,
+		Disabled:    true,
+		DebugLevel:  "warn",
 	}
 
 	c := NewConfig()
@@ -254,8 +257,9 @@ func TestYamlConfig(t *testing.T) {
 			{"url", `\s+\d+\s+`, nil, "disabled"},
 			{"url", "", []string{".jpg"}, "disabled"},
 		},
-		Disabled:   true,
-		DebugLevel: "info",
+		SQLSanitize: 2,
+		Disabled:    true,
+		DebugLevel:  "info",
 	}
 
 	out, err := yaml.Marshal(yamlConfig)
@@ -287,6 +291,7 @@ func TestYamlConfig(t *testing.T) {
 		"APPOPTICS_EVENTS_FLUSH_INTERVAL=4",
 		"APPOPTICS_EVENTS_BATCHSIZE=4000",
 		"APPOPTICS_DISABLED=true",
+		"APPOPTICS_SQL_SANITIZE=3",
 	}
 	ClearEnvs()
 	SetEnvs(envs)
@@ -325,8 +330,9 @@ func TestYamlConfig(t *testing.T) {
 			{"url", `\s+\d+\s+`, nil, "disabled"},
 			{"url", "", []string{".jpg"}, "disabled"},
 		},
-		Disabled:   true,
-		DebugLevel: "info",
+		SQLSanitize: 3,
+		Disabled:    true,
+		DebugLevel:  "info",
 	}
 
 	c = NewConfig()

--- a/v1/ao/internal/config/wrappers.go
+++ b/v1/ao/internal/config/wrappers.go
@@ -52,5 +52,8 @@ var DebugLevel = conf.GetDebugLevel
 // GetTransactionFiltering is a wrapper to the method of the global config
 var GetTransactionFiltering = conf.GetTransactionFiltering
 
+// GetSQLSanitize is a wrapper to method GetSQLSanitize of the global variable config.
+var GetSQLSanitize = conf.GetSQLSanitize
+
 // Load reads the customized configurations
 var Load = conf.Load

--- a/v1/ao/internal/reporter/sql_sanitizer.go
+++ b/v1/ao/internal/reporter/sql_sanitizer.go
@@ -10,10 +10,10 @@ import (
 
 // The SQL sanitization mode
 const (
-	// Disabled - disable SQL sanitizing.
+	// Disabled - disable SQL sanitizing (the default).
 	Disabled = iota
 	// EnabledAuto - enable SQL sanitizing and attempt to automatically determine
-	// which quoting form to use (the default).
+	// which quoting form to use.
 	EnabledAuto
 	// EnabledDropDoubleQuoted - enable SQL sanitizing and force dropping double
 	// quoted characters.

--- a/v1/ao/internal/reporter/sql_sanitizer.go
+++ b/v1/ao/internal/reporter/sql_sanitizer.go
@@ -1,14 +1,257 @@
 package reporter
 
+import (
+	"bytes"
+	"strings"
+	"unicode"
+
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/config"
+)
+
+// The SQL sanitization mode
 const (
+	// Disabled - disable SQL sanitizing.
 	Disabled = iota
+	// EnabledAuto - enable SQL sanitizing and attempt to automatically determine
+	// which quoting form to use (the default).
 	EnabledAuto
+	// EnabledDropDoubleQuoted - enable SQL sanitizing and force dropping double
+	// quoted characters.
 	EnabledDropDoubleQuoted
+	// EnabledKeepDoubleQuoted enable SQL sanitizing and force retaining double
+	// quoted character.
 	EnabledKeepDoubleQuoted
 )
 
-// SQLSanitize does the sanitization and removes the literals from the statement.
-func SQLSanitize(sql string) string {
-	// TODO
-	return sql
+// The database types
+const (
+	PostgreSQL = "postgresql"
+	Oracle     = "oracle"
+	MySQL      = "mysql"
+	Sybase     = "sybase"
+	SQLServer  = "sqlserver"
+	Default    = "default"
+)
+
+// FSMState defines the states of a FSM
+type FSMState int
+
+// The states for the SQL sanitization FSM
+const (
+	Uninitialized = iota
+	Copy
+	CopyEscape
+	StringStart
+	StringBody
+	StringEscape
+	StringEnd
+	Number
+	NumericExtension
+	Identifier
+	QuotedIdentifier
+	QuotedIdentifierEscape
+)
+
+const (
+	// ReplacementChar is the char to replace the removed literals
+	ReplacementChar = '?'
+	// EscapeChar is the SQL escape character
+	EscapeChar = '\\'
+)
+
+// SQLOperatorChars defines the list of SQL operators
+var SQLOperatorChars = map[rune]bool{
+	'.': true,
+	';': true,
+	'(': true,
+	')': true,
+	',': true,
+	'+': true,
+	'-': true,
+	'*': true,
+	'/': true,
+	'|': true,
+	'=': true,
+	'!': true,
+	'^': true,
+	'>': true,
+	'<': true,
+	'[': true,
+	']': true,
+}
+
+// SQLSanitizer sanitizes the SQL statement by removing literals from it.
+type SQLSanitizer struct {
+	// database types
+	dbType string
+	// if sanitization is enabled
+	enabled bool
+	// the quotes surrounding literals
+	literalQuotes map[rune]rune
+	// the quotes surrounding identifiers, e.g., column names
+	identifierQuotes map[rune]rune
+}
+
+// the sanitizers for various database types, which is initialized in the init
+// function.
+var sanitizers map[string]*SQLSanitizer
+
+func init() {
+	sanitizers = make(map[string]*SQLSanitizer)
+	for _, t := range []string{PostgreSQL, Oracle, MySQL, Sybase, SQLServer, Default} {
+		sanitizers[t] = NewSQLSanitizer(t)
+	}
+}
+
+// NewSQLSanitizer returns the pointer of a new SQLSanitizer.
+func NewSQLSanitizer(dbType string) *SQLSanitizer {
+	sanitizer := SQLSanitizer{
+		dbType:           strings.ToLower(dbType),
+		enabled:          true,
+		literalQuotes:    make(map[rune]rune),
+		identifierQuotes: make(map[rune]rune),
+	}
+
+	sanitizeFlag := config.GetSQLSanitize()
+	if sanitizeFlag == Disabled {
+		sanitizer.enabled = false
+		return &sanitizer
+	}
+
+	if sanitizeFlag == EnabledDropDoubleQuoted {
+		sanitizer.literalQuotes['"'] = '"'
+	} else if sanitizeFlag == EnabledKeepDoubleQuoted {
+		sanitizer.identifierQuotes['"'] = '"'
+	} else {
+		if dbType == PostgreSQL || dbType == Oracle {
+			sanitizer.identifierQuotes['"'] = '"'
+		} else {
+			sanitizer.literalQuotes['"'] = '"'
+		}
+	}
+
+	if dbType == MySQL {
+		sanitizer.identifierQuotes['`'] = '`'
+	} else if dbType == Sybase || dbType == SQLServer {
+		sanitizer.identifierQuotes['['] = ']'
+	}
+
+	return &sanitizer
+}
+
+// Sanitize does the SQL sanitization by removing literals from the statement
+func (s *SQLSanitizer) Sanitize(sql string) string {
+	var buffer bytes.Buffer
+
+	currState := Copy
+	prevState := Uninitialized
+
+	var closingQuoteChar rune
+
+	for _, currChar := range sql {
+		if currState != prevState {
+			prevState = currState
+		}
+
+		switch currState {
+		case StringStart:
+			buffer.WriteRune(ReplacementChar)
+
+			if currChar == closingQuoteChar {
+				currState = StringEnd
+			} else if currChar == EscapeChar {
+				currState = StringEscape
+			} else {
+				currState = StringBody
+			}
+
+		case StringBody:
+			if currChar == closingQuoteChar {
+				currState = StringEnd
+			} else if currChar == EscapeChar {
+				currState = StringEscape
+			}
+
+		case StringEscape:
+			currState = StringBody
+
+		case StringEnd:
+			if currChar == closingQuoteChar {
+				currState = StringBody
+			} else {
+				buffer.WriteRune(currChar)
+				currState = Copy
+			}
+
+		case CopyEscape:
+			buffer.WriteRune(currChar)
+			currState = Copy
+
+		case Number:
+			if !unicode.IsDigit(currChar) {
+				if currChar == '.' || currChar == 'E' {
+					currState = NumericExtension
+				} else {
+					buffer.WriteRune(currChar)
+					currState = Copy
+				}
+			}
+
+		case NumericExtension:
+			currState = Number
+
+		case Identifier:
+			buffer.WriteRune(currChar)
+			if c, ok := s.literalQuotes[currChar]; ok {
+				closingQuoteChar = c
+				currState = StringStart
+			} else if unicode.IsSpace(currChar) || SQLOperatorChars[currChar] {
+				currState = Copy
+			}
+
+		case QuotedIdentifier:
+			buffer.WriteRune(currChar)
+			if currChar == closingQuoteChar {
+				currState = Copy
+			} else if currChar == EscapeChar {
+				currState = QuotedIdentifierEscape
+			}
+
+		case QuotedIdentifierEscape:
+			buffer.WriteRune(currChar)
+			currState = QuotedIdentifier
+
+		default:
+			if lq, ok := s.literalQuotes[currChar]; ok {
+				closingQuoteChar = lq
+				currState = StringStart
+			} else if iq, has := s.identifierQuotes[currChar]; has {
+				buffer.WriteRune(currChar)
+				closingQuoteChar = iq
+				currState = QuotedIdentifier
+			} else if currChar == EscapeChar {
+				buffer.WriteRune(currChar)
+				currState = CopyEscape
+			} else if unicode.IsLetter(currChar) || currChar == '_' {
+				buffer.WriteRune(currChar)
+				currState = Identifier
+			} else if unicode.IsDigit(currChar) {
+				buffer.WriteRune(ReplacementChar)
+				currState = Number
+			} else {
+				buffer.WriteRune(currChar)
+			}
+		}
+	}
+
+	return buffer.String()
+}
+
+// SQLSanitize checks the sanitizer of the database type and does the sanitization
+// accordingly. It uses the default sanitizer if the type is not found.
+func SQLSanitize(sql string, dbType string) string {
+	if sanitizer, ok := sanitizers[dbType]; ok {
+		return sanitizer.Sanitize(sql)
+	}
+	return sanitizers[Default].Sanitize(sql)
 }

--- a/v1/ao/internal/reporter/sql_sanitizer.go
+++ b/v1/ao/internal/reporter/sql_sanitizer.go
@@ -1,0 +1,14 @@
+package reporter
+
+const (
+	Disabled = iota
+	EnabledAuto
+	EnabledDropDoubleQuoted
+	EnabledKeepDoubleQuoted
+)
+
+// SQLSanitize does the sanitization and removes the literals from the statement.
+func SQLSanitize(sql string) string {
+	// TODO
+	return sql
+}

--- a/v1/ao/internal/reporter/sql_sanitizer.go
+++ b/v1/ao/internal/reporter/sql_sanitizer.go
@@ -57,6 +57,8 @@ const (
 	ReplacementChar = '?'
 	// EscapeChar is the SQL escape character
 	EscapeChar = '\\'
+	// MaxSQLLen defines the maximum length
+	MaxSQLLen = 2048
 )
 
 // SQLOperatorChars defines the list of SQL operators
@@ -255,7 +257,14 @@ func (s *SQLSanitizer) Sanitize(sql string) string {
 // SQLSanitize checks the sanitizer of the database type and does the sanitization
 // accordingly. It uses the default sanitizer if the type is not found.
 func SQLSanitize(dbType string, sql string) string {
-	return sqlSanitizeInternal(sanitizers, dbType, sql)
+	return truncate(sqlSanitizeInternal(sanitizers, dbType, sql), MaxSQLLen)
+}
+
+func truncate(sql string, maxLen int) string {
+	if len(sql) <= maxLen {
+		return sql
+	}
+	return sql[:maxLen]
 }
 
 func sqlSanitizeInternal(ss map[string]*SQLSanitizer, dbType string, sql string) string {

--- a/v1/ao/internal/reporter/sql_sanitizer_test.go
+++ b/v1/ao/internal/reporter/sql_sanitizer_test.go
@@ -1,0 +1,1 @@
+package reporter

--- a/v1/ao/internal/reporter/sql_sanitizer_test.go
+++ b/v1/ao/internal/reporter/sql_sanitizer_test.go
@@ -211,7 +211,7 @@ func TestSQLSanitize(t *testing.T) {
 			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_8,
 			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_9,
 			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_10,
-             very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_11,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_11,
 			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_12,
 			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_13,
 			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_14,
@@ -232,7 +232,7 @@ func TestSQLSanitize(t *testing.T) {
 			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_8,
 			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_9,
 			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_10,
-             very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_11,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_11,
 			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_12,
 			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_13,
 			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_14,
@@ -240,7 +240,7 @@ func TestSQLSanitize(t *testing.T) {
 			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_16,
 			 FROM tmp WHERE name = ? 
 			 LEFT JOIN tickets 
-			 WHER...`,
+			 WHERE eid = i...`,
 		},
 	}
 

--- a/v1/ao/internal/reporter/sql_sanitizer_test.go
+++ b/v1/ao/internal/reporter/sql_sanitizer_test.go
@@ -190,6 +190,58 @@ func TestSQLSanitize(t *testing.T) {
 			 LEFT JOIN tickets 
 			 WHERE eid = id AND last_update BETWEEN ? AND ?`,
 		},
+		{ // unicode support
+			EnabledDropDoubleQuoted,
+			Default,
+			`select ssn from accounts where name = '中文'`,
+			`select ssn from accounts where name = ?`,
+		},
+		{ // Truncate long SQL statement
+			EnabledDropDoubleQuoted,
+			Default,
+			`WITH tmp AS (SELECT * FROM employees WHERE team = "IT") 
+			 SELECT
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_1,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_2,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_3,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_4,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_5,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_6,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_7,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_8,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_9,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_10,
+             very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_11,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_12,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_13,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_14,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_15,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_16,
+			 FROM tmp WHERE name = 'Tom' 
+			 LEFT JOIN tickets 
+			 WHERE eid = id AND last_update BETWEEN '01/01/2019' AND '05/30/2019'`,
+			`WITH tmp AS (SELECT * FROM employees WHERE team = ?) 
+			 SELECT
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_1,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_2,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_3,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_4,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_5,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_6,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_7,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_8,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_9,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_10,
+             very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_11,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_12,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_13,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_14,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_15,
+			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_16,
+			 FROM tmp WHERE name = ? 
+			 LEFT JOIN tickets 
+			 WHER...`,
+		},
 	}
 
 	for _, c := range cases {
@@ -197,7 +249,7 @@ func TestSQLSanitize(t *testing.T) {
 		assert.Nil(t, config.Load())
 		ss := initSanitizersMap()
 
-		assert.Equal(t, c.sanitizedSQL, sqlSanitizeInternal(ss, c.dbType, c.sql),
+		assert.Equal(t, c.sanitizedSQL, sqlSanitize(ss, c.dbType, c.sql),
 			fmt.Sprintf("Test case: %+v", c))
 	}
 }
@@ -215,7 +267,7 @@ func BenchmarkSQLSanitizeShort(b *testing.B) {
 	ss := initSanitizersMap()
 
 	for n := 0; n < b.N; n++ {
-		sqlSanitizeInternal(ss, Default, sql)
+		sqlSanitize(ss, Default, sql)
 	}
 	_ = os.Unsetenv("APPOPTICS_SQL_SANITIZE")
 }
@@ -230,7 +282,7 @@ func BenchmarkSQLSanitizeLong(b *testing.B) {
 	ss := initSanitizersMap()
 
 	for n := 0; n < b.N; n++ {
-		sqlSanitizeInternal(ss, Default, sql)
+		sqlSanitize(ss, Default, sql)
 	}
 	_ = os.Unsetenv("APPOPTICS_SQL_SANITIZE")
 }

--- a/v1/ao/internal/reporter/sql_sanitizer_test.go
+++ b/v1/ao/internal/reporter/sql_sanitizer_test.go
@@ -1,1 +1,189 @@
 package reporter
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// SanitizeTestCase defines the sanitizer input and output
+type SanitizeTestCase struct {
+	mode         int
+	dbType       string
+	sql          string
+	sanitizedSQL string
+}
+
+func TestSQLSanitize(t *testing.T) {
+	cases := []SanitizeTestCase{
+		// Disabled
+		{
+			Disabled,
+			MySQL,
+			"SELECT name FROM employees WHERE age = 37 AND firstName = 'Eric'",
+			"SELECT name FROM employees WHERE age = 37 AND firstName = 'Eric'",
+		},
+		{
+			Disabled,
+			Oracle,
+			"SELECT name FROM employees WHERE age = 37 AND firstName = 'Eric'",
+			"SELECT name FROM employees WHERE age = 37 AND firstName = 'Eric'",
+		},
+		{
+			Disabled,
+			Sybase,
+			"SELECT name FROM employees WHERE age = 37 AND firstName = 'Eric'",
+			"SELECT name FROM employees WHERE age = 37 AND firstName = 'Eric'",
+		},
+		{
+			Disabled,
+			SQLServer,
+			"SELECT name FROM employees WHERE age = 37 AND firstName = 'Eric'",
+			"SELECT name FROM employees WHERE age = 37 AND firstName = 'Eric'",
+		},
+		{
+			Disabled,
+			PostgreSQL,
+			"SELECT name FROM employees WHERE age = 37 AND firstName = 'Eric'",
+			"SELECT name FROM employees WHERE age = 37 AND firstName = 'Eric'",
+		},
+		{
+			Disabled,
+			Default,
+			"SELECT name FROM employees WHERE age = 37 AND firstName = 'Eric'",
+			"SELECT name FROM employees WHERE age = 37 AND firstName = 'Eric'",
+		},
+		// EnabledAuto
+		{
+			EnabledAuto,
+			Default,
+			"select * from schema.tbl where name = '';",
+			"select * from schema.tbl where name = ?;",
+		},
+		{
+			EnabledDropDoubleQuoted,
+			Default,
+			"select * from tbl where name = 'private';",
+			"select * from tbl where name = ?;",
+		},
+		{
+			EnabledKeepDoubleQuoted,
+			Default,
+			"select * from tbl where name = 'private' order by age;",
+			"select * from tbl where name = ? order by age;",
+		},
+		{
+			EnabledAuto,
+			Default,
+			"select ssn from accounts where password = \"mypass\" group by dept order by age;",
+			"select ssn from accounts where password = ? group by dept order by age;",
+		},
+		{
+			EnabledDropDoubleQuoted,
+			Default,
+			"select ssn from accounts where password = \"mypass\";",
+			"select ssn from accounts where password = ?;",
+		},
+		{
+			EnabledKeepDoubleQuoted,
+			Default,
+			"select ssn from accounts where password = \"mypass\";",
+			"select ssn from accounts where password = \"mypass\";",
+		},
+		{
+			EnabledAuto,
+			Default,
+			"select ssn from accounts where name = 'Chris O''Corner'",
+			"select ssn from accounts where name = ?",
+		},
+		{
+			EnabledAuto,
+			Default,
+			"SELECT name FROM employees WHERE age = 37 AND firstName = 'Eric'",
+			"SELECT name FROM employees WHERE age = ? AND firstName = ?",
+		},
+		{
+			EnabledAuto,
+			Default,
+			"SELECT name FROM employees WHERE name IN ('Eric', 'Tom')",
+			"SELECT name FROM employees WHERE name IN (?, ?)",
+		},
+		{
+			EnabledAuto,
+			Default,
+			"SELECT TOP 10 FROM employees WHERE age > 28",
+			"SELECT TOP ? FROM employees WHERE age > ?",
+		},
+		{
+			EnabledAuto,
+			Default,
+			"UPDATE Customers SET zip='V3B 6Z6', phone='000-000-0000'",
+			"UPDATE Customers SET zip=?, phone=?",
+		},
+		{
+			EnabledAuto,
+			Default,
+			"SELECT id FROM employees WHERE date BETWEEN '01/01/2019' AND '05/30/2019'",
+			"SELECT id FROM employees WHERE date BETWEEN ? AND ?",
+		},
+		{
+			EnabledAuto,
+			Default,
+			`SELECT name FROM employees 
+			 WHERE EXISTS (
+				SELECT eid FROM orders WHERE employees.id = orders.eid AND price > 1000
+			 )`,
+			`SELECT name FROM employees 
+			 WHERE EXISTS (
+				SELECT eid FROM orders WHERE employees.id = orders.eid AND price > ?
+			 )`,
+		},
+		{
+			EnabledAuto,
+			Default,
+			"SELECT COUNT(id), team FROM employees GROUP BY team HAVING MIN(age) > 30",
+			"SELECT COUNT(id), team FROM employees GROUP BY team HAVING MIN(age) > ?",
+		},
+		{
+			EnabledAuto,
+			Default,
+			`WITH tmp AS (SELECT * FROM employees WHERE team = 'IT') 
+			 SELECT * FROM tmp WHERE name = 'Tom'`,
+			`WITH tmp AS (SELECT * FROM employees WHERE team = ?) 
+			 SELECT * FROM tmp WHERE name = ?`,
+		},
+		{
+			EnabledKeepDoubleQuoted,
+			Oracle,
+			`WITH tmp AS (SELECT * FROM \"Employees\" WHERE team = 'IT') 
+			 SELECT * FROM tmp WHERE name = 'Tom'`,
+			`WITH tmp AS (SELECT * FROM \"Employees\" WHERE team = ?) 
+			 SELECT * FROM tmp WHERE name = ?`,
+		},
+		{
+			EnabledDropDoubleQuoted,
+			Default,
+			`WITH tmp AS (SELECT * FROM employees WHERE team = "IT") 
+			 SELECT * FROM tmp WHERE name = 'Tom' 
+			 LEFT JOIN tickets 
+			 WHERE eid = id AND last_update BETWEEN '01/01/2019' AND '05/30/2019'`,
+			`WITH tmp AS (SELECT * FROM employees WHERE team = ?) 
+			 SELECT * FROM tmp WHERE name = ? 
+			 LEFT JOIN tickets 
+			 WHERE eid = id AND last_update BETWEEN ? AND ?`,
+		},
+	}
+
+	for _, c := range cases {
+		_ = os.Setenv("APPOPTICS_SQL_SANITIZE", strconv.Itoa(c.mode))
+		assert.Nil(t, config.Load())
+		ss := initSanitizersMap()
+
+		assert.Equal(t, c.sanitizedSQL, sqlSanitizeInternal(ss, c.dbType, c.sql),
+			fmt.Sprintf("Test case: %+v", c))
+	}
+}

--- a/v1/ao/internal/reporter/sql_sanitizer_test.go
+++ b/v1/ao/internal/reporter/sql_sanitizer_test.go
@@ -53,86 +53,86 @@ func TestSQLSanitize(t *testing.T) {
 		},
 		{
 			Disabled,
-			Default,
+			DefaultDB,
 			"SELECT name FROM employees WHERE age = 37 AND firstName = 'Eric'",
 			"SELECT name FROM employees WHERE age = 37 AND firstName = 'Eric'",
 		},
 		// EnabledAuto
 		{
 			EnabledAuto,
-			Default,
+			DefaultDB,
 			"select * from schema.tbl where name = '';",
 			"select * from schema.tbl where name = ?;",
 		},
 		{
 			EnabledDropDoubleQuoted,
-			Default,
+			DefaultDB,
 			"select * from tbl where name = 'private';",
 			"select * from tbl where name = ?;",
 		},
 		{
 			EnabledKeepDoubleQuoted,
-			Default,
+			DefaultDB,
 			"select * from tbl where name = 'private' order by age;",
 			"select * from tbl where name = ? order by age;",
 		},
 		{
 			EnabledAuto,
-			Default,
+			DefaultDB,
 			"select ssn from accounts where password = \"mypass\" group by dept order by age;",
 			"select ssn from accounts where password = ? group by dept order by age;",
 		},
 		{
 			EnabledDropDoubleQuoted,
-			Default,
+			DefaultDB,
 			"select ssn from accounts where password = \"mypass\";",
 			"select ssn from accounts where password = ?;",
 		},
 		{
 			EnabledKeepDoubleQuoted,
-			Default,
+			DefaultDB,
 			"select ssn from accounts where password = \"mypass\";",
 			"select ssn from accounts where password = \"mypass\";",
 		},
 		{
 			EnabledAuto,
-			Default,
+			DefaultDB,
 			"select ssn from accounts where name = 'Chris O''Corner'",
 			"select ssn from accounts where name = ?",
 		},
 		{
 			EnabledAuto,
-			Default,
+			DefaultDB,
 			"SELECT name FROM employees WHERE age = 37 AND firstName = 'Eric'",
 			"SELECT name FROM employees WHERE age = ? AND firstName = ?",
 		},
 		{
 			EnabledAuto,
-			Default,
+			DefaultDB,
 			"SELECT name FROM employees WHERE name IN ('Eric', 'Tom')",
 			"SELECT name FROM employees WHERE name IN (?, ?)",
 		},
 		{
 			EnabledAuto,
-			Default,
+			DefaultDB,
 			"SELECT TOP 10 FROM employees WHERE age > 28",
 			"SELECT TOP ? FROM employees WHERE age > ?",
 		},
 		{
 			EnabledAuto,
-			Default,
+			DefaultDB,
 			"UPDATE Customers SET zip='V3B 6Z6', phone='000-000-0000'",
 			"UPDATE Customers SET zip=?, phone=?",
 		},
 		{
 			EnabledAuto,
-			Default,
+			DefaultDB,
 			"SELECT id FROM employees WHERE date BETWEEN '01/01/2019' AND '05/30/2019'",
 			"SELECT id FROM employees WHERE date BETWEEN ? AND ?",
 		},
 		{
 			EnabledAuto,
-			Default,
+			DefaultDB,
 			`SELECT name FROM employees 
 			 WHERE EXISTS (
 				SELECT eid FROM orders WHERE employees.id = orders.eid AND price > 1000
@@ -144,13 +144,13 @@ func TestSQLSanitize(t *testing.T) {
 		},
 		{
 			EnabledAuto,
-			Default,
+			DefaultDB,
 			"SELECT COUNT(id), team FROM employees GROUP BY team HAVING MIN(age) > 30",
 			"SELECT COUNT(id), team FROM employees GROUP BY team HAVING MIN(age) > ?",
 		},
 		{
 			EnabledAuto,
-			Default,
+			DefaultDB,
 			`WITH tmp AS (SELECT * FROM employees WHERE team = 'IT') 
 			 SELECT * FROM tmp WHERE name = 'Tom'`,
 			`WITH tmp AS (SELECT * FROM employees WHERE team = ?) 
@@ -180,7 +180,7 @@ func TestSQLSanitize(t *testing.T) {
 		},
 		{
 			EnabledDropDoubleQuoted,
-			Default,
+			DefaultDB,
 			`WITH tmp AS (SELECT * FROM employees WHERE team = "IT") 
 			 SELECT * FROM tmp WHERE name = 'Tom' 
 			 LEFT JOIN tickets 
@@ -192,13 +192,13 @@ func TestSQLSanitize(t *testing.T) {
 		},
 		{ // unicode support
 			EnabledDropDoubleQuoted,
-			Default,
+			DefaultDB,
 			`select ssn from accounts where name = '中文'`,
 			`select ssn from accounts where name = ?`,
 		},
 		{ // Truncate long SQL statement
 			EnabledDropDoubleQuoted,
-			Default,
+			DefaultDB,
 			`WITH tmp AS (SELECT * FROM employees WHERE team = "IT") 
 			 SELECT
 			 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_column_1,
@@ -267,7 +267,7 @@ func BenchmarkSQLSanitizeShort(b *testing.B) {
 	ss := initSanitizersMap()
 
 	for n := 0; n < b.N; n++ {
-		sqlSanitize(ss, Default, sql)
+		sqlSanitize(ss, DefaultDB, sql)
 	}
 	_ = os.Unsetenv("APPOPTICS_SQL_SANITIZE")
 }
@@ -282,7 +282,7 @@ func BenchmarkSQLSanitizeLong(b *testing.B) {
 	ss := initSanitizersMap()
 
 	for n := 0; n < b.N; n++ {
-		sqlSanitize(ss, Default, sql)
+		sqlSanitize(ss, DefaultDB, sql)
 	}
 	_ = os.Unsetenv("APPOPTICS_SQL_SANITIZE")
 }


### PR DESCRIPTION
The change: 
- remove literals from SQL statements reported to AO backend.

e.g., the following SQL statement:

> SELECT name FROM employees WHERE age = 37 AND firstName = 'Eric'

will be converted to:

> SELECT name FROM employees WHERE age = ? AND firstName = ?

The sanitization is configurable, see the knowledge base for more details.