### PR TITLE
[SQLSanitizationPlus] Sanitize more literal formats

### DIFF
--- a/v1/ao/internal/reporter/sql_sanitizer_test.go
+++ b/v1/ao/internal/reporter/sql_sanitizer_test.go
@@ -394,7 +394,7 @@ func TestSQLSanitize(t *testing.T) {
 		{ // PostgreSQL's double-dollar quoted literal
 			EnabledAuto,
 			PostgreSQL,
-			`SELECT * FROM employees WHERE name = $tag$Eric spends $99 '$tag$ AND gender = $tag$male$tag$`,
+			`SELECT * FROM employees WHERE name = $tag\$Eric spends $99 '\$tag\$ AND gender = $tag$male$tag$`,
 			`SELECT * FROM employees WHERE name = ? AND gender = ?`,
 		},
 		{ // PostgreSQL's double-dollar quoted literal

--- a/v1/ao/internal/reporter/sql_sanitizer_test.go
+++ b/v1/ao/internal/reporter/sql_sanitizer_test.go
@@ -385,10 +385,28 @@ func TestSQLSanitize(t *testing.T) {
 			`SELECT * FROM employees WHERE name = $tag$Eric$tag$`,
 			`SELECT * FROM employees WHERE name = ?`,
 		},
+		{ // PostgreSQL's double-dollar quoted literal with optional tag and dollar in string
+			EnabledAuto,
+			PostgreSQL,
+			`SELECT * FROM employees WHERE name = $tag$Eric spends $99 '$tag$`,
+			`SELECT * FROM employees WHERE name = ?`,
+		},
+		{ // PostgreSQL's double-dollar quoted literal
+			EnabledAuto,
+			PostgreSQL,
+			`SELECT * FROM employees WHERE name = $tag$Eric spends $99 '$tag$ AND gender = $tag$male$tag$`,
+			`SELECT * FROM employees WHERE name = ? AND gender = ?`,
+		},
 		{ // PostgreSQL's double-dollar quoted literal
 			EnabledAuto,
 			PostgreSQL,
 			`SELECT * FROM employees WHERE name = $$Eric$$`,
+			`SELECT * FROM employees WHERE name = ?`,
+		},
+		{ // PostgreSQL's double-dollar quoted literal with escape rune
+			EnabledAuto,
+			PostgreSQL,
+			`SELECT * FROM employees WHERE name = $$Eric$$$`,
 			`SELECT * FROM employees WHERE name = ?`,
 		},
 		{ // Oracle's special treatment when literal replacement is turned on

--- a/v1/ao/internal/reporter/sql_sanitizer_test.go
+++ b/v1/ao/internal/reporter/sql_sanitizer_test.go
@@ -373,6 +373,36 @@ func TestSQLSanitize(t *testing.T) {
 			"SELECT",
 			"SELECT",
 		},
+		{ // PostgreSQL's special literal formats
+			EnabledAuto,
+			PostgreSQL,
+			`SELECT * FROM employees WHERE name = B'0101'`,
+			`SELECT * FROM employees WHERE name = ?`,
+		},
+		{ // PostgreSQL's double-dollar quoted literal with optional tag
+			EnabledAuto,
+			PostgreSQL,
+			`SELECT * FROM employees WHERE name = $tag$Eric$tag$`,
+			`SELECT * FROM employees WHERE name = ?`,
+		},
+		{ // PostgreSQL's double-dollar quoted literal
+			EnabledAuto,
+			PostgreSQL,
+			`SELECT * FROM employees WHERE name = $$Eric$$`,
+			`SELECT * FROM employees WHERE name = ?`,
+		},
+		{ // Oracle's special treatment when literal replacement is turned on
+			EnabledAuto,
+			Oracle,
+			`SELECT * FROM employees WHERE name = U'500 Oracle Parkway'`,
+			`SELECT * FROM employees WHERE name = ?`,
+		},
+		{ // Oracle's N function
+			EnabledAuto,
+			Oracle,
+			`SELECT * FROM employees WHERE name = N'500 Oracle Parkway'`,
+			`SELECT * FROM employees WHERE name = ?`,
+		},
 	}
 
 	for _, c := range cases {

--- a/v1/ao/internal/utils/version.go
+++ b/v1/ao/internal/utils/version.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	// The AppOptics Go agent version
-	version = "1.8.0"
+	version = "1.8.1"
 
 	// The Go version
 	goVersion = strings.TrimPrefix(runtime.Version(), "go")


### PR DESCRIPTION
Add support to the following PostgreSQL string formats:

Bit-String: ... where name = B'0101'
Hex-String: ... where name = X'FEFF'
String constants with Unicode escapes: ... where name = U&'d\0061t+000061'
Dollar-Quoted String Constants: ... where name = $optionalTag$Dianne's horse$optionalTag$