### PR TITLE
AO-13526: Trigger Trace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 test:
-	go test -v -race -timeout 3m ./... && echo "All tests passed."
+	go test -race -timeout 3m -short ./... && echo "All tests passed."

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	go test -v -race -timeout 3m ./... && echo "All tests passed."

--- a/examples/appoptics-config.yaml
+++ b/examples/appoptics-config.yaml
@@ -19,3 +19,4 @@ ServiceKey: your_service_key:your_service_name  # - env var: APPOPTICS_SERVICE_K
 # Disabled: false  # - env var: APPOPTICS_DISABLED
 # Ec2MetadataTimeout: 1000 # - env var: APPOPTICS_EC2_METADATA_TIMEOUT
 # DebugLevel: warn  # - env var: APPOPTICS_DEBUG_LEVEL
+# TriggerTrace: false # - env var: APPOPTICS_TRIGGER_TRACE

--- a/examples/appoptics-config.yaml
+++ b/examples/appoptics-config.yaml
@@ -19,4 +19,4 @@ ServiceKey: your_service_key:your_service_name  # - env var: APPOPTICS_SERVICE_K
 # Disabled: false  # - env var: APPOPTICS_DISABLED
 # Ec2MetadataTimeout: 1000 # - env var: APPOPTICS_EC2_METADATA_TIMEOUT
 # DebugLevel: warn  # - env var: APPOPTICS_DEBUG_LEVEL
-# TriggerTrace: false # - env var: APPOPTICS_TRIGGER_TRACE
+# TriggerTrace: true # - env var: APPOPTICS_TRIGGER_TRACE

--- a/examples/distributed_app/alice/main_test.go
+++ b/examples/distributed_app/alice/main_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func TestClient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping this test case in short mode")
+	}
 	// run distributed_app server
 
 	// test request to distributed_app example

--- a/v1/ao/http_instrumentation.go
+++ b/v1/ao/http_instrumentation.go
@@ -176,15 +176,15 @@ func CheckTriggerTraceHeader(header map[string][]string) (reporter.TriggerTraceM
 			v = kvSlice[1] // no trim space per the spec
 		}
 
-		if !(strings.HasPrefix(strings.ToLower(k), "custom_") ||
-			k == "pd_keys" ||
-			k == "trigger_trace" ||
+		if !(strings.HasPrefix(strings.ToLower(k), "custom-") ||
+			k == "pd-keys" ||
+			k == "trigger-trace" ||
 			k == "ts") {
 			ignoredKeys = append(ignoredKeys, k)
 			continue
 		}
 
-		if k == "pd_keys" {
+		if k == "pd-keys" {
 			k = "PDKeys"
 		}
 
@@ -194,13 +194,13 @@ func CheckTriggerTraceHeader(header map[string][]string) (reporter.TriggerTraceM
 			kvs[k] = v
 		}
 	}
-	val, forceTrace := kvs["trigger_trace"]
+	val, forceTrace := kvs["trigger-trace"]
 	if val != "" {
-		log.Debug("trigger_trace should not contain any value.")
+		log.Debug("trigger-trace should not contain any value.")
 		forceTrace = false
-		ignoredKeys = append(ignoredKeys, "trigger_trace")
+		ignoredKeys = append(ignoredKeys, "trigger-trace")
 	}
-	delete(kvs, "trigger_trace")
+	delete(kvs, "trigger-trace")
 
 	sigSlice := header[textproto.CanonicalMIMEHeaderKey(HTTPHeaderXTraceOptionsSignature)]
 	signature := ""

--- a/v1/ao/http_instrumentation.go
+++ b/v1/ao/http_instrumentation.go
@@ -20,8 +20,12 @@ import (
 const (
 	// HTTPHeaderName is a constant for the HTTP header used by AppOptics ("X-Trace") to propagate
 	// the distributed tracing context across HTTP requests.
-	HTTPHeaderName                   = "X-Trace"
-	HTTPHeaderXTraceOptions          = reporter.HTTPHeaderXTraceOptions
+	HTTPHeaderName = "X-Trace"
+	// HTTPHeaderXTraceOptions is a constant for the HTTP header to propagate X-Trace-Options
+	// values. It's for trigger trace requests and may be used for other purposes in the future.
+	HTTPHeaderXTraceOptions = reporter.HTTPHeaderXTraceOptions
+	// HTTPHeaderXTraceOptionsSignature is a constant for the HTTP headers to propagate
+	// X-Trace-Options-Signature values. It contains the response codes for X-Trace-Options
 	HTTPHeaderXTraceOptionsSignature = reporter.HTTPHeaderXTraceOptionsSignature
 	httpHandlerSpanName              = "http.HandlerFunc"
 )

--- a/v1/ao/http_instrumentation_oboe_test.go
+++ b/v1/ao/http_instrumentation_oboe_test.go
@@ -19,7 +19,7 @@ func TestCustomTransactionNameWithDomain(t *testing.T) {
 	r := reporter.SetTestReporter() // set up test reporter
 
 	// Test prepending the domain to transaction names.
-	httpTestWithEndpoint(handler200, "http://test.com/hello world/one/two/three?testq")
+	httpTestWithEndpoint(handler200CustomTxnName, "http://test.com/hello world/one/two/three?testq")
 	r.Close(2)
 	g.AssertGraph(t, r.EventBufs, 2, g.AssertNodeMap{
 		// entry event should have no edges
@@ -40,7 +40,7 @@ func TestCustomTransactionNameWithDomain(t *testing.T) {
 	hd := map[string]string{
 		"X-Forwarded-Host": "test2.com",
 	}
-	httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello world/one/two/three?testq", hd)
+	httpTestWithEndpointWithHeaders(handler200CustomTxnName, "http://test.com/hello world/one/two/three?testq", hd)
 	r.Close(2)
 	g.AssertGraph(t, r.EventBufs, 2, g.AssertNodeMap{
 		// entry event should have no edges

--- a/v1/ao/internal/config/config.go
+++ b/v1/ao/internal/config/config.go
@@ -115,6 +115,9 @@ type Config struct {
 
 	// The default log level. It should follow the level defined in log.DefaultLevel
 	DebugLevel string `yaml:"DebugLevel,omitempty" env:"APPOPTICS_DEBUG_LEVEL" default:"warn"`
+
+	// If trigger trace is enabled
+	TriggerTrace bool `yaml:"TriggerTrace,omitempty" env:"APPOPTICS_TRIGGER_TRACE"`
 }
 
 // SamplingConfig defines the configuration options for the sampling decision

--- a/v1/ao/internal/config/config.go
+++ b/v1/ao/internal/config/config.go
@@ -117,7 +117,7 @@ type Config struct {
 	DebugLevel string `yaml:"DebugLevel,omitempty" env:"APPOPTICS_DEBUG_LEVEL" default:"warn"`
 
 	// If trigger trace is enabled
-	TriggerTrace bool `yaml:"TriggerTrace,omitempty" env:"APPOPTICS_TRIGGER_TRACE"`
+	TriggerTrace bool `yaml:"TriggerTrace" env:"APPOPTICS_TRIGGER_TRACE" default:"true"`
 }
 
 // SamplingConfig defines the configuration options for the sampling decision
@@ -798,6 +798,13 @@ func (c *Config) GetDebugLevel() string {
 	c.RLock()
 	defer c.RUnlock()
 	return c.DebugLevel
+}
+
+// GetTriggerTrace returns the trigger trace configuration
+func (c *Config) GetTriggerTrace() bool {
+	c.RLock()
+	defer c.RUnlock()
+	return c.TriggerTrace
 }
 
 // GetTransactionFiltering returns the transaction filtering config

--- a/v1/ao/internal/config/config.go
+++ b/v1/ao/internal/config/config.go
@@ -116,7 +116,7 @@ type Config struct {
 	// The default log level. It should follow the level defined in log.DefaultLevel
 	DebugLevel string `yaml:"DebugLevel,omitempty" env:"APPOPTICS_DEBUG_LEVEL" default:"warn"`
 
-	// If trigger trace is enabled
+	// The flag for trigger trace. It's enabled by default.
 	TriggerTrace bool `yaml:"TriggerTrace" env:"APPOPTICS_TRIGGER_TRACE" default:"true"`
 }
 

--- a/v1/ao/internal/config/config_test.go
+++ b/v1/ao/internal/config/config_test.go
@@ -143,6 +143,7 @@ func TestConfigInit(t *testing.T) {
 		Disabled:           false,
 		Ec2MetadataTimeout: 1000,
 		DebugLevel:         "warn",
+		TriggerTrace:       false,
 	}
 	assert.Equal(t, *c, defaultC)
 }
@@ -183,6 +184,7 @@ func TestEnvsLoading(t *testing.T) {
 		"APPOPTICS_DISABLED=true",
 		"APPOPTICS_SQL_SANITIZE=0",
 		"APPOPTICS_EC2_METADATA_TIMEOUT=2000",
+		"APPOPTICS_TRIGGER_TRACE=true",
 	}
 	SetEnvs(envs)
 
@@ -219,6 +221,7 @@ func TestEnvsLoading(t *testing.T) {
 		Disabled:           true,
 		Ec2MetadataTimeout: 2000,
 		DebugLevel:         "warn",
+		TriggerTrace:       true,
 	}
 
 	c := NewConfig()
@@ -264,6 +267,7 @@ func TestYamlConfig(t *testing.T) {
 		Disabled:           true,
 		Ec2MetadataTimeout: 1500,
 		DebugLevel:         "info",
+		TriggerTrace:       true,
 	}
 
 	out, err := yaml.Marshal(yamlConfig)
@@ -338,6 +342,7 @@ func TestYamlConfig(t *testing.T) {
 		Disabled:           true,
 		Ec2MetadataTimeout: 1500,
 		DebugLevel:         "info",
+		TriggerTrace:       true,
 	}
 
 	c = NewConfig()

--- a/v1/ao/internal/config/config_test.go
+++ b/v1/ao/internal/config/config_test.go
@@ -143,7 +143,7 @@ func TestConfigInit(t *testing.T) {
 		Disabled:           false,
 		Ec2MetadataTimeout: 1000,
 		DebugLevel:         "warn",
-		TriggerTrace:       false,
+		TriggerTrace:       true,
 	}
 	assert.Equal(t, *c, defaultC)
 }
@@ -184,7 +184,7 @@ func TestEnvsLoading(t *testing.T) {
 		"APPOPTICS_DISABLED=true",
 		"APPOPTICS_SQL_SANITIZE=0",
 		"APPOPTICS_EC2_METADATA_TIMEOUT=2000",
-		"APPOPTICS_TRIGGER_TRACE=true",
+		"APPOPTICS_TRIGGER_TRACE=false",
 	}
 	SetEnvs(envs)
 
@@ -221,7 +221,7 @@ func TestEnvsLoading(t *testing.T) {
 		Disabled:           true,
 		Ec2MetadataTimeout: 2000,
 		DebugLevel:         "warn",
-		TriggerTrace:       true,
+		TriggerTrace:       false,
 	}
 
 	c := NewConfig()
@@ -267,7 +267,7 @@ func TestYamlConfig(t *testing.T) {
 		Disabled:           true,
 		Ec2MetadataTimeout: 1500,
 		DebugLevel:         "info",
-		TriggerTrace:       true,
+		TriggerTrace:       false,
 	}
 
 	out, err := yaml.Marshal(yamlConfig)
@@ -342,7 +342,7 @@ func TestYamlConfig(t *testing.T) {
 		Disabled:           true,
 		Ec2MetadataTimeout: 1500,
 		DebugLevel:         "info",
-		TriggerTrace:       true,
+		TriggerTrace:       false,
 	}
 
 	c = NewConfig()

--- a/v1/ao/internal/config/wrappers.go
+++ b/v1/ao/internal/config/wrappers.go
@@ -52,8 +52,8 @@ var GetEc2MetadataTimeout = conf.GetEc2MetadataTimeout
 // DebugLevel is a wrapper to the method of the global config
 var DebugLevel = conf.GetDebugLevel
 
-// DebugLevel is a wrapper to the method of the global config
-var TriggerTrace = conf.TriggerTrace
+// GetTriggerTrace is a wrapper to the method of the global config
+var GetTriggerTrace = conf.GetTriggerTrace
 
 // GetTransactionFiltering is a wrapper to the method of the global config
 var GetTransactionFiltering = conf.GetTransactionFiltering

--- a/v1/ao/internal/config/wrappers.go
+++ b/v1/ao/internal/config/wrappers.go
@@ -52,6 +52,9 @@ var GetEc2MetadataTimeout = conf.GetEc2MetadataTimeout
 // DebugLevel is a wrapper to the method of the global config
 var DebugLevel = conf.GetDebugLevel
 
+// DebugLevel is a wrapper to the method of the global config
+var TriggerTrace = conf.TriggerTrace
+
 // GetTransactionFiltering is a wrapper to the method of the global config
 var GetTransactionFiltering = conf.GetTransactionFiltering
 

--- a/v1/ao/internal/metrics/metrics.go
+++ b/v1/ao/internal/metrics/metrics.go
@@ -289,7 +289,7 @@ func init() {
 // metricsFlushInterval	current metrics flush interval
 //
 // return				metrics message in BSON format
-func GenerateMetricsMessage(metricsFlushInterval int, qs EventQueueStats, rc RateCounts) []byte {
+func GenerateMetricsMessage(metricsFlushInterval int, qs EventQueueStats, rcs map[string]RateCounts) []byte {
 	bbuf := bson.NewBuffer()
 
 	appendHostId(bbuf)
@@ -302,11 +302,13 @@ func GenerateMetricsMessage(metricsFlushInterval int, qs EventQueueStats, rc Rat
 	index := 0
 
 	// request counters
-	addMetricsValue(bbuf, &index, "RequestCount", rc.Requested())
-	addMetricsValue(bbuf, &index, "TraceCount", rc.Traced())
-	addMetricsValue(bbuf, &index, "TokenBucketExhaustionCount", rc.Limited())
-	addMetricsValue(bbuf, &index, "SampleCount", rc.Sampled())
-	addMetricsValue(bbuf, &index, "ThroughTraceCount", rc.Through())
+	for prefix, rc := range rcs {
+		addMetricsValue(bbuf, &index, prefix+"RequestCount", rc.Requested())
+		addMetricsValue(bbuf, &index, prefix+"TraceCount", rc.Traced())
+		addMetricsValue(bbuf, &index, prefix+"TokenBucketExhaustionCount", rc.Limited())
+		addMetricsValue(bbuf, &index, prefix+"SampleCount", rc.Sampled())
+		addMetricsValue(bbuf, &index, prefix+"ThroughTraceCount", rc.Through())
+	}
 
 	// Queue states
 	addMetricsValue(bbuf, &index, "NumSent", qs.numSent)

--- a/v1/ao/internal/metrics/metrics.go
+++ b/v1/ao/internal/metrics/metrics.go
@@ -305,7 +305,7 @@ func init() {
 
 // addRequestCounters add various request-related counters to the metrics message buffer.
 func addRequestCounters(bbuf *bson.Buffer, index *int, rcs map[string]*RateCounts) {
-	var requested, traced, limited int64
+	var requested, traced, limited, ttTraced int64
 
 	for _, rc := range rcs {
 		requested += rc.Requested()
@@ -322,10 +322,14 @@ func addRequestCounters(bbuf *bson.Buffer, index *int, rcs map[string]*RateCount
 		addMetricsValue(bbuf, index, ThroughTraceCount, rcRegular.Through())
 	}
 
-	if rcTT, ok := rcs[RCRelaxedTriggerTrace]; ok {
-		ttTraced := rcTT.Traced() + rcTT.Traced()
-		addMetricsValue(bbuf, index, TriggeredTraceCount, ttTraced)
+	if relaxed, ok := rcs[RCRelaxedTriggerTrace]; ok {
+		ttTraced += relaxed.Traced()
 	}
+	if strict, ok := rcs[RCStrictTriggerTrace]; ok {
+		ttTraced += strict.Traced()
+	}
+
+	addMetricsValue(bbuf, index, TriggeredTraceCount, ttTraced)
 }
 
 // GenerateMetricsMessage generates a metrics message in BSON format with all the currently available values

--- a/v1/ao/internal/metrics/metrics_test.go
+++ b/v1/ao/internal/metrics/metrics_test.go
@@ -370,7 +370,8 @@ func TestAddHistogramToBSON(t *testing.T) {
 }
 
 func TestGenerateMetricsMessage(t *testing.T) {
-	bbuf := bson.WithBuf(GenerateMetricsMessage(15, EventQueueStats{}, RateCounts{}))
+	bbuf := bson.WithBuf(GenerateMetricsMessage(15, EventQueueStats{},
+		map[string]RateCounts{"": {}}))
 	m := bsonToMap(bbuf)
 
 	_, ok := m["Hostname"]
@@ -440,7 +441,8 @@ func TestGenerateMetricsMessage(t *testing.T) {
 			break
 		}
 	}
-	m = bsonToMap(bson.WithBuf(GenerateMetricsMessage(15, EventQueueStats{}, RateCounts{})))
+	m = bsonToMap(bson.WithBuf(GenerateMetricsMessage(15, EventQueueStats{},
+		map[string]RateCounts{"": {}})))
 
 	assert.NotNil(t, m["TransactionNameOverflow"])
 	assert.True(t, m["TransactionNameOverflow"].(bool))

--- a/v1/ao/internal/metrics/metrics_test.go
+++ b/v1/ao/internal/metrics/metrics_test.go
@@ -371,7 +371,10 @@ func TestAddHistogramToBSON(t *testing.T) {
 
 func TestGenerateMetricsMessage(t *testing.T) {
 	bbuf := bson.WithBuf(GenerateMetricsMessage(15, EventQueueStats{},
-		map[string]*RateCounts{RCRegular: {}, RCRelaxedTriggerTrace: {}, RCStrictTriggerTrace: {}}))
+		map[string]*RateCounts{ // requested, sampled, limited, traced, through
+			RCRegular:             {10, 2, 5, 5, 1},
+			RCRelaxedTriggerTrace: {3, 0, 1, 2, 0},
+			RCStrictTriggerTrace:  {4, 0, 3, 1, 0}}))
 	m := bsonToMap(bbuf)
 
 	_, ok := m["Hostname"]
@@ -390,15 +393,13 @@ func TestGenerateMetricsMessage(t *testing.T) {
 		value interface{}
 	}
 
-	// TODO add request counters
-
 	testCases := []testCase{
-		{"RequestCount", int64(1)},
-		{"TraceCount", int64(1)},
-		{"TokenBucketExhaustionCount", int64(1)},
-		{"SampleCount", int64(1)},
+		{"RequestCount", int64(10)},
+		{"TraceCount", int64(5)},
+		{"TokenBucketExhaustionCount", int64(5)},
+		{"SampleCount", int64(2)},
 		{"ThroughTraceCount", int64(1)},
-		{"TriggeredTraceCount", int64(1)},
+		{"TriggeredTraceCount", int64(3)},
 		{"NumSent", int64(1)},
 		{"NumOverflowed", int64(1)},
 		{"NumFailed", int64(1)},

--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -366,7 +366,7 @@ func NewContext(layer string, reportEntry bool, opts ContextOptions,
 			setting, has := getSetting(layer)
 			if !has {
 				if opts.TriggerTrace.Enabled() {
-					SetHeaders("trigger_trace=settings-not-available")
+					SetHeaders("trigger-trace=settings-not-available")
 				}
 				return ctx, false, headers
 			}
@@ -375,7 +375,7 @@ func NewContext(layer string, reportEntry bool, opts ContextOptions,
 			ctx.SetEnabled(flags.Enabled())
 			if opts.XTraceOptions {
 				if opts.TriggerTrace.Enabled() {
-					SetHeaders("trigger_trace=ignored")
+					SetHeaders("trigger-trace=ignored")
 				} else {
 					SetHeaders("ok")
 				}

--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -323,13 +323,13 @@ func newContextFromMetadataString(mdstr string) (*oboeContext, error) {
 // NewContext starts a trace, possibly continuing one, if mdStr is provided. Setting reportEntry will
 // report an entry event before this function returns, calling cb if provided for additional KV pairs.
 func NewContext(layer, mdStr string, reportEntry bool, cb func() map[string]interface{}) (ctx Context, ok bool) {
-	return NewContextForURL(layer, mdStr, reportEntry, "", cb)
+	return NewContextForURL(layer, mdStr, reportEntry, "", false, cb)
 }
 
 // NewContextForURL starts a trace for the provided URL, possibly continuing one, if mdStr is provided.
 // Setting reportEntry will report an entry event before this function returns, calling cb if provided
 // for additional KV pairs.
-func NewContextForURL(layer, mdStr string, reportEntry bool, url string, cb func() map[string]interface{}) (ctx Context, ok bool) {
+func NewContextForURL(layer, mdStr string, reportEntry bool, url string, triggerTrace bool, cb func() map[string]interface{}) (ctx Context, ok bool) {
 	traced := false
 	addCtxEdge := false
 
@@ -358,7 +358,7 @@ func NewContextForURL(layer, mdStr string, reportEntry bool, url string, cb func
 		ctx = newContext(true)
 	}
 
-	ok, rate, source, enabled := shouldTraceRequestWithURL(layer, traced, url)
+	ok, rate, source, enabled := shouldTraceRequestWithURL(layer, traced, url, triggerTrace)
 	if ok {
 		if reportEntry {
 			var kvs map[string]interface{}

--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -544,7 +544,7 @@ func NewContext(layer string, reportEntry bool, opts ContextOptions,
 			_, flags, _ := mergeURLSetting(setting, opts.URL)
 			ctx.SetEnabled(flags.Enabled())
 
-			if tMode.Enabled() {
+			if tMode.Requested() {
 				SetHeaders("ignored")
 			} else {
 				SetHeaders("not-requested")

--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -464,6 +464,9 @@ func getTriggerTraceToken() ([]byte, error) {
 	if !ok {
 		return nil, errors.New("failed to get settings")
 	}
+	if len(setting.triggerToken) == 0 {
+		return nil, errors.New("no valid signature key found")
+	}
 	return setting.triggerToken, nil
 }
 

--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -364,7 +364,7 @@ func NewContext(layer string, reportEntry bool, opts ContextOptions,
 				if opts.TriggerTrace {
 					SetHeaders("force_trace=settings-not-available")
 				}
-				return ctx, false, headers // TODO: return true to attach headers here?
+				return ctx, false, headers
 			}
 
 			_, flags, _ := mergeURLSetting(setting, opts.URL)

--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -32,6 +32,7 @@ const (
 )
 
 const HTTPHeaderXTraceOptions = "X-Trace-Options"
+const HTTPHeaderXTraceOptionsSignature = "X-Trace-Options-Signature"
 const HTTPHeaderXTraceOptionsResponse = "X-Trace-Options-Response"
 
 // orchestras tune to the oboe.
@@ -66,7 +67,7 @@ type ContextOptions struct {
 	URL string
 
 	XTraceOptions bool
-	TriggerTrace  bool
+	TriggerTrace  TriggerTraceMode
 
 	CB func() KVMap
 }
@@ -364,7 +365,7 @@ func NewContext(layer string, reportEntry bool, opts ContextOptions,
 		} else {
 			setting, has := getSetting(layer)
 			if !has {
-				if opts.TriggerTrace {
+				if opts.TriggerTrace.Enabled() {
 					SetHeaders("trigger_trace=settings-not-available")
 				}
 				return ctx, false, headers
@@ -373,7 +374,7 @@ func NewContext(layer string, reportEntry bool, opts ContextOptions,
 			_, flags, _ := mergeURLSetting(setting, opts.URL)
 			ctx.SetEnabled(flags.Enabled())
 			if opts.XTraceOptions {
-				if opts.TriggerTrace {
+				if opts.TriggerTrace.Enabled() {
 					SetHeaders("trigger_trace=ignored")
 				} else {
 					SetHeaders("ok")

--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -360,6 +360,7 @@ func parseTriggerTraceFlag(opts, sig string) (TriggerTraceMode, map[string]strin
 		kvSlice := strings.SplitN(opt, "=", 2)
 		var k, v string
 		k = strings.TrimSpace(kvSlice[0])
+
 		if len(kvSlice) == 2 {
 			v = strings.TrimSpace(kvSlice[1])
 		} else if kvSlice[0] != "trigger-trace" {

--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -406,7 +406,7 @@ func NewContext(layer string, reportEntry bool, opts ContextOptions,
 				return &nullContext{}, false, headers
 			}
 		}
-		if opts.TriggerTrace {
+		if opts.XTraceOptions {
 			SetHeaders(decision.xTraceOptsRsp)
 		}
 		return ctx, true, headers
@@ -414,7 +414,7 @@ func NewContext(layer string, reportEntry bool, opts ContextOptions,
 
 	ctx.SetSampled(false)
 	ctx.SetEnabled(decision.enabled)
-	if opts.TriggerTrace {
+	if opts.XTraceOptions {
 		SetHeaders(decision.xTraceOptsRsp)
 	}
 	return ctx, true, headers

--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -362,7 +362,7 @@ func NewContext(layer string, reportEntry bool, opts ContextOptions,
 			setting, has := getSetting(layer)
 			if !has {
 				if opts.TriggerTrace {
-					SetHeaders("force_trace=settings-not-available")
+					SetHeaders("trigger_trace=settings-not-available")
 				}
 				return ctx, false, headers
 			}
@@ -371,7 +371,7 @@ func NewContext(layer string, reportEntry bool, opts ContextOptions,
 			ctx.SetEnabled(flags.Enabled())
 			if opts.XTraceOptions {
 				if opts.TriggerTrace {
-					SetHeaders("force_trace=ignored")
+					SetHeaders("trigger_trace=ignored")
 				} else {
 					SetHeaders("ok")
 				}

--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -71,9 +71,9 @@ type ContextOptions struct {
 	MdStr string
 	// URL is used to do the URL-based transaction filtering.
 	URL string
-	// XTraceOptions is the value of the X-Trace-Options header.
+	// XTraceOptions represents the X-Trace-Options header.
 	XTraceOptions string
-	// XTraceOptions is the value of the X-Trace-Options-Signature header.
+	// XTraceOptionsSignature represents the X-Trace-Options-Signature header.
 	XTraceOptionsSignature string
 	// CB is the callback function to produce the KVs.
 	CB func() KVMap

--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -31,6 +31,9 @@ const (
 	XTR_FLAGS_SAMPLED = 0x1
 )
 
+const HTTPHeaderXTraceOptions = "X-Trace-Options"
+const HTTPHeaderXTraceOptionsResponse = "X-Trace-Options-Response"
+
 // orchestras tune to the oboe.
 type oboeIDs struct{ taskID, opID []byte }
 
@@ -346,7 +349,7 @@ func NewContext(layer string, reportEntry bool, opts ContextOptions,
 		if headers == nil {
 			headers = make(map[string]string)
 		}
-		headers["X-Trace-Options-Response"] = v
+		headers[HTTPHeaderXTraceOptionsResponse] = v
 	}
 
 	if opts.MdStr != "" {

--- a/v1/ao/internal/reporter/context_test.go
+++ b/v1/ao/internal/reporter/context_test.go
@@ -229,7 +229,7 @@ func TestNewContextForURL(t *testing.T) {
 
 	// test invalid metadata string
 	ctx, ok, _ := NewContext("testBadMDSpan", true, ContextOptions{
-		MdStr: "hello", URL: "", TriggerTrace: ModeXTraceOptionsNotPresent}, nil)
+		MdStr: "hello", URL: "", XTraceOptions: "", XTraceOptionsSignature: ""}, nil)
 
 	assert.True(t, ok) // bad metadata string should get ignored
 	assert.Equal(t, reflect.TypeOf(ctx).Elem().Name(), "oboeContext")
@@ -237,7 +237,7 @@ func TestNewContextForURL(t *testing.T) {
 	oldMD := "1BF4CAA9299299E3D38A58A9821BD34F6268E576CFAB2A2203"
 	// test old metadata string
 	ctx, ok, _ = NewContext("testOldMDSpan", true, ContextOptions{
-		MdStr: oldMD, URL: "", TriggerTrace: ModeXTraceOptionsNotPresent}, nil)
+		MdStr: oldMD, URL: "", XTraceOptions: "", XTraceOptionsSignature: ""}, nil)
 
 	assert.True(t, ok) // old metadata string should get ignore
 	assert.Equal(t, reflect.TypeOf(ctx).Elem().Name(), "oboeContext")
@@ -255,7 +255,7 @@ func TestNewContextForURLTracingDisabled(t *testing.T) {
 
 	// create a valid context even if tracing is disabled
 	ctx, ok, _ := NewContext("testLayer", false, ContextOptions{
-		MdStr: "", URL: "", TriggerTrace: ModeXTraceOptionsNotPresent}, nil)
+		MdStr: "", URL: "", XTraceOptions: "", XTraceOptionsSignature: ""}, nil)
 
 	assert.True(t, ok)
 	assert.Equal(t, reflect.TypeOf(ctx).Elem().Name(), "oboeContext")
@@ -288,7 +288,7 @@ func TestNullContext(t *testing.T) {
 	// shouldn't be able to create a trace if the entry event fails
 	r.ShouldError = true
 	ctxBad, ok, _ := NewContext("testBadEntry", true, ContextOptions{
-		MdStr: "", URL: "", TriggerTrace: ModeXTraceOptionsNotPresent}, nil)
+		MdStr: "", URL: "", XTraceOptions: "", XTraceOptionsSignature: ""}, nil)
 	assert.False(t, ok)
 	assert.Equal(t, reflect.TypeOf(ctxBad).Elem().Name(), "nullContext")
 	assert.False(t, ctxBad.IsSampled())

--- a/v1/ao/internal/reporter/context_test.go
+++ b/v1/ao/internal/reporter/context_test.go
@@ -325,6 +325,6 @@ func TestParseTriggerTraceFlag(t *testing.T) {
 	opts = "trigger-trace;pd-keys=lo:se,check-id:123"
 	sig := "2c1c398c3e6be898f47f74bf74f035903b48b59c"
 	mode, kvs, ignored, err = parseTriggerTraceFlag(opts, sig)
-	assert.EqualValues(t, ModeNoTriggerTrace, mode)
+	assert.EqualValues(t, ModeInvalidTriggerTrace, mode)
 	assert.NotNil(t, err)
 }

--- a/v1/ao/internal/reporter/context_test.go
+++ b/v1/ao/internal/reporter/context_test.go
@@ -224,16 +224,20 @@ func TestReportEventMap(t *testing.T) {
 	})
 }
 
-func TestNewContext(t *testing.T) {
+func TestNewContextForURL(t *testing.T) {
 	r := SetTestReporter()
 
-	ctx, ok := NewContext("testBadMDSpan", "hello", true, nil) // test invalid metadata string
-	assert.True(t, ok)                                         // bad metadata string should get ignored
+	// test invalid metadata string
+	ctx, ok, _ := NewContext("testBadMDSpan", true, ContextOptions{MdStr: "hello", URL: "", TriggerTrace: false}, nil)
+
+	assert.True(t, ok) // bad metadata string should get ignored
 	assert.Equal(t, reflect.TypeOf(ctx).Elem().Name(), "oboeContext")
 
 	oldMD := "1BF4CAA9299299E3D38A58A9821BD34F6268E576CFAB2A2203"
-	ctx, ok = NewContext("testOldMDSpan", oldMD, true, nil) // test old metadata string
-	assert.True(t, ok)                                      // old metadata string should get ignore
+	// test old metadata string
+	ctx, ok, _ = NewContext("testOldMDSpan", true, ContextOptions{MdStr: oldMD, URL: "", TriggerTrace: false}, nil)
+
+	assert.True(t, ok) // old metadata string should get ignore
 	assert.Equal(t, reflect.TypeOf(ctx).Elem().Name(), "oboeContext")
 
 	r.Close(2)
@@ -244,11 +248,12 @@ func TestNewContext(t *testing.T) {
 	})
 }
 
-func TestNewContextTracingDisabled(t *testing.T) {
+func TestNewContextForURLTracingDisabled(t *testing.T) {
 	r := SetTestReporter(TestReporterDisableTracing()) // set up test reporter
 
 	// create a valid context even if tracing is disabled
-	ctx, ok := NewContext("testLayer", "", false, nil)
+	ctx, ok, _ := NewContext("testLayer", false, ContextOptions{MdStr: "", URL: "", TriggerTrace: false}, nil)
+
 	assert.True(t, ok)
 	assert.Equal(t, reflect.TypeOf(ctx).Elem().Name(), "oboeContext")
 	assert.False(t, ctx.IsSampled())
@@ -279,7 +284,7 @@ func TestNullContext(t *testing.T) {
 
 	// shouldn't be able to create a trace if the entry event fails
 	r.ShouldError = true
-	ctxBad, ok := NewContext("testBadEntry", "", true, nil)
+	ctxBad, ok, _ := NewContext("testBadEntry", true, ContextOptions{MdStr: "", URL: "", TriggerTrace: false}, nil)
 	assert.False(t, ok)
 	assert.Equal(t, reflect.TypeOf(ctxBad).Elem().Name(), "nullContext")
 	assert.False(t, ctxBad.IsSampled())

--- a/v1/ao/internal/reporter/context_test.go
+++ b/v1/ao/internal/reporter/context_test.go
@@ -133,7 +133,7 @@ func TestMetadata(t *testing.T) {
 
 	// isSampled()
 	var md3 oboeMetadata
-	md3.FromString(md1Str)
+	_ = md3.FromString(md1Str)
 	ctx3 := &oboeContext{metadata: md3}
 	ctx3.SetSampled(true)
 	assert.True(t, ctx3.IsSampled())
@@ -228,14 +228,16 @@ func TestNewContextForURL(t *testing.T) {
 	r := SetTestReporter()
 
 	// test invalid metadata string
-	ctx, ok, _ := NewContext("testBadMDSpan", true, ContextOptions{MdStr: "hello", URL: "", TriggerTrace: false}, nil)
+	ctx, ok, _ := NewContext("testBadMDSpan", true, ContextOptions{
+		MdStr: "hello", URL: "", TriggerTrace: ModeXTraceOptionsNotPresent}, nil)
 
 	assert.True(t, ok) // bad metadata string should get ignored
 	assert.Equal(t, reflect.TypeOf(ctx).Elem().Name(), "oboeContext")
 
 	oldMD := "1BF4CAA9299299E3D38A58A9821BD34F6268E576CFAB2A2203"
 	// test old metadata string
-	ctx, ok, _ = NewContext("testOldMDSpan", true, ContextOptions{MdStr: oldMD, URL: "", TriggerTrace: false}, nil)
+	ctx, ok, _ = NewContext("testOldMDSpan", true, ContextOptions{
+		MdStr: oldMD, URL: "", TriggerTrace: ModeXTraceOptionsNotPresent}, nil)
 
 	assert.True(t, ok) // old metadata string should get ignore
 	assert.Equal(t, reflect.TypeOf(ctx).Elem().Name(), "oboeContext")
@@ -252,7 +254,8 @@ func TestNewContextForURLTracingDisabled(t *testing.T) {
 	r := SetTestReporter(TestReporterDisableTracing()) // set up test reporter
 
 	// create a valid context even if tracing is disabled
-	ctx, ok, _ := NewContext("testLayer", false, ContextOptions{MdStr: "", URL: "", TriggerTrace: false}, nil)
+	ctx, ok, _ := NewContext("testLayer", false, ContextOptions{
+		MdStr: "", URL: "", TriggerTrace: ModeXTraceOptionsNotPresent}, nil)
 
 	assert.True(t, ok)
 	assert.Equal(t, reflect.TypeOf(ctx).Elem().Name(), "oboeContext")
@@ -284,7 +287,8 @@ func TestNullContext(t *testing.T) {
 
 	// shouldn't be able to create a trace if the entry event fails
 	r.ShouldError = true
-	ctxBad, ok, _ := NewContext("testBadEntry", true, ContextOptions{MdStr: "", URL: "", TriggerTrace: false}, nil)
+	ctxBad, ok, _ := NewContext("testBadEntry", true, ContextOptions{
+		MdStr: "", URL: "", TriggerTrace: ModeXTraceOptionsNotPresent}, nil)
 	assert.False(t, ok)
 	assert.Equal(t, reflect.TypeOf(ctxBad).Elem().Name(), "nullContext")
 	assert.False(t, ctxBad.IsSampled())

--- a/v1/ao/internal/reporter/event.go
+++ b/v1/ao/internal/reporter/event.go
@@ -80,10 +80,11 @@ const (
 
 // source of the sample value
 const (
-	SAMPLE_SOURCE_NONE    sampleSource = 0
-	SAMPLE_SOURCE_FILE    sampleSource = 1
-	SAMPLE_SOURCE_DEFAULT sampleSource = 2
-	SAMPLE_SOURCE_LAYER   sampleSource = 3
+	SAMPLE_SOURCE_UNSET sampleSource = iota - 1
+	SAMPLE_SOURCE_NONE
+	SAMPLE_SOURCE_FILE
+	SAMPLE_SOURCE_DEFAULT
+	SAMPLE_SOURCE_LAYER
 )
 
 const (

--- a/v1/ao/internal/reporter/event.go
+++ b/v1/ao/internal/reporter/event.go
@@ -64,7 +64,7 @@ const (
 	FlagSampleStartOffset
 	FlagSampleThroughOffset
 	FlagSampleThroughAlwaysOffset
-	FlagForceTraceOffset
+	FlagTriggerTraceOffset
 )
 
 // setting flags
@@ -75,7 +75,7 @@ const (
 	FLAG_SAMPLE_START          settingFlag = 1 << FlagSampleStartOffset
 	FLAG_SAMPLE_THROUGH        settingFlag = 1 << FlagSampleThroughOffset
 	FLAG_SAMPLE_THROUGH_ALWAYS settingFlag = 1 << FlagSampleThroughAlwaysOffset
-	FLAG_FORCE_TRACE           settingFlag = 1 << FlagForceTraceOffset
+	FLAG_TRIGGER_TRACE         settingFlag = 1 << FlagTriggerTraceOffset
 )
 
 // source of the sample value
@@ -97,7 +97,7 @@ func (f settingFlag) Enabled() bool {
 
 // TriggerTraceEnabled returns if the trigger trace is enabled
 func (f settingFlag) TriggerTraceEnabled() bool {
-	return f&FLAG_FORCE_TRACE != 0
+	return f&FLAG_TRIGGER_TRACE != 0
 }
 
 func (st settingType) toSampleSource() sampleSource {
@@ -132,7 +132,7 @@ func (tm tracingMode) isUnknown() bool {
 func (tm tracingMode) toFlags() settingFlag {
 	switch tm {
 	case TRACE_ENABLED:
-		return FLAG_SAMPLE_START | FLAG_SAMPLE_THROUGH_ALWAYS | FLAG_FORCE_TRACE
+		return FLAG_SAMPLE_START | FLAG_SAMPLE_THROUGH_ALWAYS | FLAG_TRIGGER_TRACE
 	case TRACE_DISABLED:
 	default:
 	}

--- a/v1/ao/internal/reporter/event.go
+++ b/v1/ao/internal/reporter/event.go
@@ -65,6 +65,7 @@ const (
 	FLAG_SAMPLE_START          settingFlag = 0x4
 	FLAG_SAMPLE_THROUGH        settingFlag = 0x8
 	FLAG_SAMPLE_THROUGH_ALWAYS settingFlag = 0x10
+	FLAG_FORCE_TRACE           settingFlag = 0x20
 )
 
 // source of the sample value

--- a/v1/ao/internal/reporter/event.go
+++ b/v1/ao/internal/reporter/event.go
@@ -57,15 +57,25 @@ const (
 	TYPE_LAYER                      // layer specific settings
 )
 
+// setting flags offset
+const (
+	FlagInvalidOffset = iota
+	FlagOverrideOffset
+	FlagSampleStartOffset
+	FlagSampleThroughOffset
+	FlagSampleThroughAlwaysOffset
+	FlagForceTraceOffset
+)
+
 // setting flags
 const (
 	FLAG_OK                    settingFlag = 0x0
-	FLAG_INVALID               settingFlag = 0x1
-	FLAG_OVERRIDE              settingFlag = 0x2
-	FLAG_SAMPLE_START          settingFlag = 0x4
-	FLAG_SAMPLE_THROUGH        settingFlag = 0x8
-	FLAG_SAMPLE_THROUGH_ALWAYS settingFlag = 0x10
-	FLAG_FORCE_TRACE           settingFlag = 0x20
+	FLAG_INVALID               settingFlag = 1 << FlagInvalidOffset
+	FLAG_OVERRIDE              settingFlag = 1 << FlagOverrideOffset
+	FLAG_SAMPLE_START          settingFlag = 1 << FlagSampleStartOffset
+	FLAG_SAMPLE_THROUGH        settingFlag = 1 << FlagSampleThroughOffset
+	FLAG_SAMPLE_THROUGH_ALWAYS settingFlag = 1 << FlagSampleThroughAlwaysOffset
+	FLAG_FORCE_TRACE           settingFlag = 1 << FlagForceTraceOffset
 )
 
 // source of the sample value
@@ -83,6 +93,11 @@ const (
 // Enabled returns if the trace is enabled or not.
 func (f settingFlag) Enabled() bool {
 	return f&(FLAG_SAMPLE_START|FLAG_SAMPLE_THROUGH_ALWAYS) != 0
+}
+
+// TriggerTraceEnabled returns if the trigger trace is enabled
+func (f settingFlag) TriggerTraceEnabled() bool {
+	return f&FLAG_FORCE_TRACE != 0
 }
 
 func (st settingType) toSampleSource() sampleSource {
@@ -117,7 +132,7 @@ func (tm tracingMode) isUnknown() bool {
 func (tm tracingMode) toFlags() settingFlag {
 	switch tm {
 	case TRACE_ENABLED:
-		return FLAG_SAMPLE_START | FLAG_SAMPLE_THROUGH_ALWAYS
+		return FLAG_SAMPLE_START | FLAG_SAMPLE_THROUGH_ALWAYS | FLAG_FORCE_TRACE
 	case TRACE_DISABLED:
 	default:
 	}

--- a/v1/ao/internal/reporter/event_test.go
+++ b/v1/ao/internal/reporter/event_test.go
@@ -186,7 +186,7 @@ func TestSettingTypeToSampleSource(t *testing.T) {
 }
 
 func TestTracingModeToFlags(t *testing.T) {
-	assert.Equal(t, FLAG_SAMPLE_START|FLAG_SAMPLE_THROUGH_ALWAYS|FLAG_FORCE_TRACE, newTracingMode(config.EnabledTracingMode).toFlags())
+	assert.Equal(t, FLAG_SAMPLE_START|FLAG_SAMPLE_THROUGH_ALWAYS|FLAG_TRIGGER_TRACE, newTracingMode(config.EnabledTracingMode).toFlags())
 	assert.Equal(t, FLAG_OK, newTracingMode(config.DisabledTracingMode).toFlags())
 	assert.Equal(t, FLAG_OK, tracingMode(100).toFlags())
 }

--- a/v1/ao/internal/reporter/event_test.go
+++ b/v1/ao/internal/reporter/event_test.go
@@ -186,7 +186,7 @@ func TestSettingTypeToSampleSource(t *testing.T) {
 }
 
 func TestTracingModeToFlags(t *testing.T) {
-	assert.Equal(t, FLAG_SAMPLE_START|FLAG_SAMPLE_THROUGH_ALWAYS, newTracingMode(config.EnabledTracingMode).toFlags())
+	assert.Equal(t, FLAG_SAMPLE_START|FLAG_SAMPLE_THROUGH_ALWAYS|FLAG_FORCE_TRACE, newTracingMode(config.EnabledTracingMode).toFlags())
 	assert.Equal(t, FLAG_OK, newTracingMode(config.DisabledTracingMode).toFlags())
 	assert.Equal(t, FLAG_OK, tracingMode(100).toFlags())
 }

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -323,7 +323,7 @@ func oboeSampleRequest(layer string, traced bool, url string, triggerTrace Trigg
 	retval = bucket.count(retval, traced, doRateLimiting)
 
 	rsp := "not-requested"
-	if triggerTrace.Enabled() {
+	if triggerTrace.Requested() {
 		rsp = "ignored"
 	}
 	return SampleDecision{retval, sampleRate, source, flags.Enabled(), rsp}

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -200,7 +200,7 @@ func oboeSampleRequest(layer string, traced bool, url string, triggerTrace bool)
 	var setting *oboeSettings
 	var ok bool
 	if setting, ok = getSetting(layer); !ok {
-		return SampleDecision{false, 0, SAMPLE_SOURCE_NONE, false, "settings-not-available"}
+		return SampleDecision{false, 0, SAMPLE_SOURCE_NONE, false, "force_trace=settings-not-available"}
 	}
 
 	retval := false
@@ -208,18 +208,18 @@ func oboeSampleRequest(layer string, traced bool, url string, triggerTrace bool)
 
 	sampleRate, flags, source := mergeURLSetting(setting, url)
 
-	if triggerTrace {
-		rsp := "ok"
+	if triggerTrace && !traced {
+		rsp := "force_trace=ok"
 
 		if setting.forceTrace && flags.Enabled() {
 			ret := setting.triggerTraceBucket.count(true, false, true)
 			if !ret {
-				rsp = "rate-exceeded"
+				rsp = "force_trace=rate-exceeded"
 			}
 			return SampleDecision{ret, setting.value, setting.source, setting.flags.Enabled(), rsp} // TODO: is the value/source correct?
 		} else {
 			if !flags.Enabled() {
-				rsp = "trace-mode-disabled"
+				rsp = "force_trace=trace-mode-disabled"
 			}
 			return SampleDecision{false, 0, SAMPLE_SOURCE_NONE, false, rsp} // TODO: check ret value
 		}
@@ -243,9 +243,10 @@ func oboeSampleRequest(layer string, traced bool, url string, triggerTrace bool)
 	}
 
 	retval = setting.bucket.count(retval, traced, doRateLimiting)
+
 	rsp := "ok"
-	if !retval {
-		rsp = "rate-exceeded" // TODO: ?? undetermined
+	if triggerTrace {
+		rsp = "force_trace=ignored"
 	}
 	return SampleDecision{retval, sampleRate, source, flags.Enabled(), rsp}
 }

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -270,17 +270,17 @@ func oboeSampleRequest(layer string, traced bool, url string, triggerTrace Trigg
 			if !ret {
 				rsp = "rate-exceeded"
 			}
-			return SampleDecision{ret, setting.value, setting.source, true, rsp} // TODO: is the value/source correct?
+			return SampleDecision{ret, -1, SAMPLE_SOURCE_UNSET, true, rsp}
 		} else {
 			if !flags.Enabled() {
 				rsp = "tracing-disabled"
 			} else {
 				rsp = "disabled"
 			}
-			return SampleDecision{false, 0, SAMPLE_SOURCE_NONE, false, rsp} // TODO: check ret value
+			return SampleDecision{false, -1, SAMPLE_SOURCE_UNSET, false, rsp}
 		}
 	} else if triggerTrace == ModeNoTriggerTrace {
-		return SampleDecision{false, 0, SAMPLE_SOURCE_NONE, false, ""}
+		return SampleDecision{false, -1, SAMPLE_SOURCE_UNSET, false, ""}
 	}
 
 	if !traced {

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -180,7 +180,7 @@ func (b *tokenBucket) update(now time.Time) {
 	}
 }
 
-func oboeSampleRequest(layer string, traced bool, url string) (bool, int, sampleSource, bool) {
+func oboeSampleRequest(layer string, traced bool, url string, triggerTrace bool) (bool, int, sampleSource, bool) {
 	if usingTestReporter {
 		if r, ok := globalReporter.(*TestReporter); ok {
 			if !r.UseSettings {
@@ -193,6 +193,12 @@ func oboeSampleRequest(layer string, traced bool, url string) (bool, int, sample
 	var ok bool
 	if setting, ok = getSetting(layer); !ok {
 		return false, 0, SAMPLE_SOURCE_NONE, false
+	}
+
+	if setting.forceTrace && triggerTrace {
+		// TODO: handle trigger trace
+		retval := setting.triggerTraceBucket.count(true, false, true)
+		return retval, setting.value, setting.source, setting.flags.Enabled() // TODO: is the value/source correct?
 	}
 
 	retval := false

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -297,7 +297,7 @@ func oboeSampleRequest(layer string, traced bool, url string, triggerTrace Trigg
 			if !flags.Enabled() {
 				rsp = "tracing-disabled"
 			} else {
-				rsp = "disabled"
+				rsp = "trigger-tracing-disabled"
 			}
 		}
 		return SampleDecision{ret, -1, SAMPLE_SOURCE_UNSET, flags.Enabled(), rsp}

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -24,15 +24,16 @@ type oboeSettingsCfg struct {
 	lock     sync.RWMutex
 }
 
-func FlushRateCounts() map[string]metrics.RateCounts {
+// FlushRateCounts collects the request counters values by categories.
+func FlushRateCounts() map[string]*metrics.RateCounts {
 	setting, ok := getSetting("")
 	if !ok {
 		return nil
 	}
-	rcs := make(map[string]metrics.RateCounts)
-	rcs[""] = setting.bucket.FlushRateCounts()
-	rcs["RelaxedTriggerTrace"] = setting.triggerTraceRelaxedBucket.FlushRateCounts()
-	rcs["StrictTriggerTrace"] = setting.triggerTraceStrictBucket.FlushRateCounts()
+	rcs := make(map[string]*metrics.RateCounts)
+	rcs[metrics.RCRegular] = setting.bucket.FlushRateCounts()
+	rcs[metrics.RCRelaxedTriggerTrace] = setting.triggerTraceRelaxedBucket.FlushRateCounts()
+	rcs[metrics.RCStrictTriggerTrace] = setting.triggerTraceStrictBucket.FlushRateCounts()
 
 	return rcs
 }

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -236,7 +236,7 @@ func oboeSampleRequest(layer string, traced bool, url string, triggerTrace Trigg
 	var setting *oboeSettings
 	var ok bool
 	if setting, ok = getSetting(layer); !ok {
-		return SampleDecision{false, 0, SAMPLE_SOURCE_NONE, false, "trigger-trace=settings-not-available"}
+		return SampleDecision{false, 0, SAMPLE_SOURCE_NONE, false, "settings-not-available"}
 	}
 
 	retval := false
@@ -245,23 +245,23 @@ func oboeSampleRequest(layer string, traced bool, url string, triggerTrace Trigg
 	sampleRate, flags, source := mergeURLSetting(setting, url)
 
 	if triggerTrace.Enabled() && !traced {
-		rsp := "trigger-trace=ok"
+		rsp := "ok"
 
-		if flags.TriggerTraceEnabled() { // TODO: should return (no fallback sampling) for relaxed trace with bad signature
+		if flags.TriggerTraceEnabled() {
 			bucket := setting.triggerTraceRelaxedBucket
 			if triggerTrace == ModeStrictTriggerTrace {
 				bucket = setting.triggerTraceStrictBucket
 			}
 			ret := bucket.count(true, false, true)
 			if !ret {
-				rsp = "trigger-trace=rate-exceeded"
+				rsp = "rate-exceeded"
 			}
 			return SampleDecision{ret, setting.value, setting.source, true, rsp} // TODO: is the value/source correct?
 		} else {
 			if !flags.Enabled() {
-				rsp = "trigger-trace=tracing-disabled"
+				rsp = "tracing-disabled"
 			} else {
-				rsp = "trigger-trace=disabled"
+				rsp = "disabled"
 			}
 			return SampleDecision{false, 0, SAMPLE_SOURCE_NONE, false, rsp} // TODO: check ret value
 		}
@@ -286,9 +286,9 @@ func oboeSampleRequest(layer string, traced bool, url string, triggerTrace Trigg
 
 	retval = setting.bucket.count(retval, traced, doRateLimiting)
 
-	rsp := "trigger-trace=not-requested"
+	rsp := "not-requested"
 	if triggerTrace.Enabled() {
-		rsp = "trigger-trace=ignored"
+		rsp = "ignored"
 	}
 	return SampleDecision{retval, sampleRate, source, flags.Enabled(), rsp}
 }

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -245,7 +245,7 @@ func oboeSampleRequest(layer string, traced bool, url string, triggerTrace bool)
 
 	retval = setting.bucket.count(retval, traced, doRateLimiting)
 
-	rsp := "ok"
+	rsp := "trigger-trace=not-requested"
 	if triggerTrace {
 		rsp = "trigger_trace=ignored"
 	}

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -200,7 +200,7 @@ func oboeSampleRequest(layer string, traced bool, url string, triggerTrace bool)
 	var setting *oboeSettings
 	var ok bool
 	if setting, ok = getSetting(layer); !ok {
-		return SampleDecision{false, 0, SAMPLE_SOURCE_NONE, false, "force_trace=settings-not-available"}
+		return SampleDecision{false, 0, SAMPLE_SOURCE_NONE, false, "trigger_trace=settings-not-available"}
 	}
 
 	retval := false
@@ -209,17 +209,17 @@ func oboeSampleRequest(layer string, traced bool, url string, triggerTrace bool)
 	sampleRate, flags, source := mergeURLSetting(setting, url)
 
 	if triggerTrace && !traced {
-		rsp := "force_trace=ok"
+		rsp := "trigger_trace=ok"
 
 		if setting.forceTrace && flags.Enabled() {
 			ret := setting.triggerTraceBucket.count(true, false, true)
 			if !ret {
-				rsp = "force_trace=rate-exceeded"
+				rsp = "trigger_trace=rate-exceeded"
 			}
 			return SampleDecision{ret, setting.value, setting.source, setting.flags.Enabled(), rsp} // TODO: is the value/source correct?
 		} else {
 			if !flags.Enabled() {
-				rsp = "force_trace=trace-mode-disabled"
+				rsp = "trigger_trace=trace-mode-disabled"
 			}
 			return SampleDecision{false, 0, SAMPLE_SOURCE_NONE, false, rsp} // TODO: check ret value
 		}
@@ -246,7 +246,7 @@ func oboeSampleRequest(layer string, traced bool, url string, triggerTrace bool)
 
 	rsp := "ok"
 	if triggerTrace {
-		rsp = "force_trace=ignored"
+		rsp = "trigger_trace=ignored"
 	}
 	return SampleDecision{retval, sampleRate, source, flags.Enabled(), rsp}
 }

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -236,7 +236,7 @@ func oboeSampleRequest(layer string, traced bool, url string, triggerTrace Trigg
 	var setting *oboeSettings
 	var ok bool
 	if setting, ok = getSetting(layer); !ok {
-		return SampleDecision{false, 0, SAMPLE_SOURCE_NONE, false, "trigger_trace=settings-not-available"}
+		return SampleDecision{false, 0, SAMPLE_SOURCE_NONE, false, "trigger-trace=settings-not-available"}
 	}
 
 	retval := false
@@ -245,7 +245,7 @@ func oboeSampleRequest(layer string, traced bool, url string, triggerTrace Trigg
 	sampleRate, flags, source := mergeURLSetting(setting, url)
 
 	if triggerTrace.Enabled() && !traced {
-		rsp := "trigger_trace=ok"
+		rsp := "trigger-trace=ok"
 
 		if flags.TriggerTraceEnabled() { // TODO: should return (no fallback sampling) for relaxed trace with bad signature
 			bucket := setting.triggerTraceRelaxedBucket
@@ -254,14 +254,14 @@ func oboeSampleRequest(layer string, traced bool, url string, triggerTrace Trigg
 			}
 			ret := bucket.count(true, false, true)
 			if !ret {
-				rsp = "trigger_trace=rate-exceeded"
+				rsp = "trigger-trace=rate-exceeded"
 			}
 			return SampleDecision{ret, setting.value, setting.source, true, rsp} // TODO: is the value/source correct?
 		} else {
 			if !flags.Enabled() {
-				rsp = "trigger_trace=tracing-disabled"
+				rsp = "trigger-trace=tracing-disabled"
 			} else {
-				rsp = "trigger_trace=disabled"
+				rsp = "trigger-trace=disabled"
 			}
 			return SampleDecision{false, 0, SAMPLE_SOURCE_NONE, false, rsp} // TODO: check ret value
 		}
@@ -288,7 +288,7 @@ func oboeSampleRequest(layer string, traced bool, url string, triggerTrace Trigg
 
 	rsp := "trigger-trace=not-requested"
 	if triggerTrace.Enabled() {
-		rsp = "trigger_trace=ignored"
+		rsp = "trigger-trace=ignored"
 	}
 	return SampleDecision{retval, sampleRate, source, flags.Enabled(), rsp}
 }

--- a/v1/ao/internal/reporter/oboe_test.go
+++ b/v1/ao/internal/reporter/oboe_test.go
@@ -251,7 +251,7 @@ func TestSampleFlags(t *testing.T) {
 		{Type: "url", RegEx: `user\d{3}`, Tracing: config.DisabledTracingMode},
 		{Type: "url", Extensions: []string{".png", ".jpg"}, Tracing: config.DisabledTracingMode},
 	})
-	ok, _, _, _ = shouldTraceRequestWithURL(testLayer, false, "http://test.com/user123")
+	ok, _, _, _ = shouldTraceRequestWithURL(testLayer, false, "http://test.com/user123", false)
 	assert.False(t, ok)
 
 	resetSettings()

--- a/v1/ao/internal/reporter/oboe_test.go
+++ b/v1/ao/internal/reporter/oboe_test.go
@@ -126,7 +126,7 @@ func TestSamplingRate(t *testing.T) {
 	// set 2.5% sampling rate
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		25000, 120, argsToMap(1000000, 1000000, -1, -1))
+		25000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
 
 	total := 100000
 	traced := callShouldTraceRequest(total, false)
@@ -169,14 +169,14 @@ func TestSampleRateBoundaries(t *testing.T) {
 	// check that max value doesn't go above 1000000
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000001, 120, argsToMap(1000000, 1000000, -1, -1))
+		1000001, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
 
 	_, rate, _, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, 1000000, rate)
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		0, 120, argsToMap(1000000, 1000000, -1, -1))
+		0, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
 
 	_, rate, _, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, 0, rate)
@@ -184,7 +184,7 @@ func TestSampleRateBoundaries(t *testing.T) {
 	// check that min value doesn't go below 0
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		-1, 120, argsToMap(1000000, 1000000, -1, -1))
+		-1, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
 
 	_, rate, _, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, 0, rate)
@@ -205,14 +205,14 @@ func TestSampleSource(t *testing.T) {
 	// we're currently only looking up default settings, so this should return NONE sample source
 	updateSetting(int32(TYPE_LAYER), testLayer,
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
 	_, _, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_NONE, source)
 
 	// as soon as we add the default settings back, we get a valid sample source
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
 	_, _, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_DEFAULT, source)
 
@@ -225,7 +225,7 @@ func TestSampleFlags(t *testing.T) {
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte(""),
-		1000000, 120, argsToMap(1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
 	ok, _, _, _ := shouldTraceRequest(testLayer, false)
 	assert.False(t, ok)
 	assert.EqualValues(t, 0, c.Through())
@@ -238,7 +238,7 @@ func TestSampleFlags(t *testing.T) {
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START"),
-		1000000, 120, argsToMap(1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
 	ok, _, _, _ = shouldTraceRequest(testLayer, false)
 	assert.True(t, ok)
 	assert.EqualValues(t, 0, c.Through())
@@ -259,7 +259,7 @@ func TestSampleFlags(t *testing.T) {
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
 	ok, _, _, _ = shouldTraceRequest(testLayer, false)
 	assert.False(t, ok)
 	assert.EqualValues(t, 0, c.Through())
@@ -272,7 +272,7 @@ func TestSampleFlags(t *testing.T) {
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_THROUGH"),
-		1000000, 120, argsToMap(1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
 	ok, _, _, _ = shouldTraceRequest(testLayer, false)
 	assert.False(t, ok)
 	assert.EqualValues(t, 0, c.Through())
@@ -298,7 +298,7 @@ func TestSampleTokenBucket(t *testing.T) {
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START"),
-		1000000, 120, argsToMap(0, 0, -1, -1))
+		1000000, 120, argsToMap(0, 0, 0, 0, -1, -1))
 	traced = callShouldTraceRequest(1, false)
 	assert.EqualValues(t, 0, traced)
 	assert.EqualValues(t, 0, c.Traced())
@@ -310,7 +310,7 @@ func TestSampleTokenBucket(t *testing.T) {
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(16, 8, -1, -1))
+		1000000, 120, argsToMap(16, 8, 16, 8, -1, -1))
 	traced = callShouldTraceRequest(50, false)
 	assert.EqualValues(t, 16, traced)
 	assert.EqualValues(t, 16, c.Traced())
@@ -439,10 +439,10 @@ func TestMergeRemoteSettingWithLocalConfig(t *testing.T) {
 	// Remote setting has the override flag && local config has lower rate
 	_ = os.Setenv("APPOPTICS_TRACING_MODE", "enabled")
 	_ = os.Setenv("APPOPTICS_SAMPLE_RATE", "10000")
-	config.Load()
+	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("OVERRIDE,SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_FILE, source)
 	assert.Equal(t, 10000, rate)
@@ -450,10 +450,10 @@ func TestMergeRemoteSettingWithLocalConfig(t *testing.T) {
 	// Remote setting has the override flag && local config has higher rate
 	_ = os.Setenv("APPOPTICS_TRACING_MODE", "enabled")
 	_ = os.Setenv("APPOPTICS_SAMPLE_RATE", "10000")
-	config.Load()
+	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("OVERRIDE,SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000, 120, argsToMap(1000000, 1000000, -1, -1))
+		1000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_DEFAULT, source)
 	assert.Equal(t, 1000, rate)
@@ -461,50 +461,50 @@ func TestMergeRemoteSettingWithLocalConfig(t *testing.T) {
 	// Remote setting doesn't have the override flag && local config has lower rate
 	_ = os.Setenv("APPOPTICS_TRACING_MODE", "enabled")
 	_ = os.Setenv("APPOPTICS_SAMPLE_RATE", "10000")
-	config.Load()
+	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_FILE, source)
 	assert.Equal(t, 10000, rate)
 	// Remote setting doesn't have the override flag && local config has higher rate
 	_ = os.Setenv("APPOPTICS_TRACING_MODE", "enabled")
 	_ = os.Setenv("APPOPTICS_SAMPLE_RATE", "10000")
-	config.Load()
+	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000, 120, argsToMap(1000000, 1000000, -1, -1))
+		1000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_FILE, source)
 	assert.Equal(t, 10000, rate)
 	// Remote setting has the override flag && no local config
 	_ = os.Unsetenv("APPOPTICS_TRACING_MODE")
 	_ = os.Unsetenv("APPOPTICS_SAMPLE_RATE")
-	config.Load()
+	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("OVERRIDE,SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		10000, 120, argsToMap(1000000, 1000000, -1, -1))
+		10000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_DEFAULT, source)
 	assert.Equal(t, 10000, rate)
 	// Remote setting doesn't have the override flag && no local config
 	_ = os.Unsetenv("APPOPTICS_TRACING_MODE")
 	_ = os.Unsetenv("APPOPTICS_SAMPLE_RATE")
-	config.Load()
+	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		10000, 120, argsToMap(1000000, 1000000, -1, -1))
+		10000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_DEFAULT, source)
 	assert.Equal(t, 10000, rate)
 	// Remote setting has the override flag && local tracing mode = DISABLED
 	_ = os.Setenv("APPOPTICS_TRACING_MODE", "disabled")
 	_ = os.Setenv("APPOPTICS_SAMPLE_RATE", "10000")
-	config.Load()
+	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("OVERRIDE,SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_FILE, source)
 	assert.Equal(t, 10000, rate)

--- a/v1/ao/internal/reporter/oboe_test.go
+++ b/v1/ao/internal/reporter/oboe_test.go
@@ -261,7 +261,7 @@ func TestSampleFlags(t *testing.T) {
 		{Type: "url", RegEx: `user\d{3}`, Tracing: config.DisabledTracingMode},
 		{Type: "url", Extensions: []string{".png", ".jpg"}, Tracing: config.DisabledTracingMode},
 	})
-	decision := shouldTraceRequestWithURL(testLayer, false, "http://test.com/user123", ModeXTraceOptionsNotPresent)
+	decision := shouldTraceRequestWithURL(testLayer, false, "http://test.com/user123", ModeTriggerTraceNotPresent)
 	assert.False(t, decision.trace)
 
 	resetSettings()

--- a/v1/ao/internal/reporter/oboe_test.go
+++ b/v1/ao/internal/reporter/oboe_test.go
@@ -126,7 +126,7 @@ func TestSamplingRate(t *testing.T) {
 	// set 2.5% sampling rate
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		25000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		25000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte("")))
 
 	total := 100000
 	traced := callShouldTraceRequest(total, false)
@@ -169,14 +169,14 @@ func TestSampleRateBoundaries(t *testing.T) {
 	// check that max value doesn't go above 1000000
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000001, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000001, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte("")))
 
 	_, rate, _, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, 1000000, rate)
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		0, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		0, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte("")))
 
 	_, rate, _, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, 0, rate)
@@ -184,7 +184,7 @@ func TestSampleRateBoundaries(t *testing.T) {
 	// check that min value doesn't go below 0
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		-1, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		-1, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte("")))
 
 	_, rate, _, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, 0, rate)
@@ -205,14 +205,14 @@ func TestSampleSource(t *testing.T) {
 	// we're currently only looking up default settings, so this should return NONE sample source
 	updateSetting(int32(TYPE_LAYER), testLayer,
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte("")))
 	_, _, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_NONE, source)
 
 	// as soon as we add the default settings back, we get a valid sample source
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte("")))
 	_, _, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_DEFAULT, source)
 
@@ -225,7 +225,7 @@ func TestSampleFlags(t *testing.T) {
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte(""),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte("")))
 	ok, _, _, _ := shouldTraceRequest(testLayer, false)
 	assert.False(t, ok)
 	assert.EqualValues(t, 0, c.Through())
@@ -238,7 +238,7 @@ func TestSampleFlags(t *testing.T) {
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte("")))
 	ok, _, _, _ = shouldTraceRequest(testLayer, false)
 	assert.True(t, ok)
 	assert.EqualValues(t, 0, c.Through())
@@ -259,7 +259,7 @@ func TestSampleFlags(t *testing.T) {
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte("")))
 	ok, _, _, _ = shouldTraceRequest(testLayer, false)
 	assert.False(t, ok)
 	assert.EqualValues(t, 0, c.Through())
@@ -272,7 +272,7 @@ func TestSampleFlags(t *testing.T) {
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_THROUGH"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte("")))
 	ok, _, _, _ = shouldTraceRequest(testLayer, false)
 	assert.False(t, ok)
 	assert.EqualValues(t, 0, c.Through())
@@ -298,7 +298,7 @@ func TestSampleTokenBucket(t *testing.T) {
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START"),
-		1000000, 120, argsToMap(0, 0, 0, 0, 0, 0, -1, -1))
+		1000000, 120, argsToMap(0, 0, 0, 0, 0, 0, -1, -1, []byte("")))
 	traced = callShouldTraceRequest(1, false)
 	assert.EqualValues(t, 0, traced)
 	assert.EqualValues(t, 0, c.Traced())
@@ -310,7 +310,7 @@ func TestSampleTokenBucket(t *testing.T) {
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(16, 8, 16, 8, 16, 8, -1, -1))
+		1000000, 120, argsToMap(16, 8, 16, 8, 16, 8, -1, -1, []byte("")))
 	traced = callShouldTraceRequest(50, false)
 	assert.EqualValues(t, 16, traced)
 	assert.EqualValues(t, 16, c.Traced())
@@ -442,7 +442,7 @@ func TestMergeRemoteSettingWithLocalConfig(t *testing.T) {
 	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("OVERRIDE,SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte("")))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_FILE, source)
 	assert.Equal(t, 10000, rate)
@@ -453,7 +453,7 @@ func TestMergeRemoteSettingWithLocalConfig(t *testing.T) {
 	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("OVERRIDE,SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte("")))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_DEFAULT, source)
 	assert.Equal(t, 1000, rate)
@@ -464,7 +464,7 @@ func TestMergeRemoteSettingWithLocalConfig(t *testing.T) {
 	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte("")))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_FILE, source)
 	assert.Equal(t, 10000, rate)
@@ -474,7 +474,7 @@ func TestMergeRemoteSettingWithLocalConfig(t *testing.T) {
 	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte("")))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_FILE, source)
 	assert.Equal(t, 10000, rate)
@@ -484,7 +484,7 @@ func TestMergeRemoteSettingWithLocalConfig(t *testing.T) {
 	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("OVERRIDE,SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		10000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		10000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte("")))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_DEFAULT, source)
 	assert.Equal(t, 10000, rate)
@@ -494,7 +494,7 @@ func TestMergeRemoteSettingWithLocalConfig(t *testing.T) {
 	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		10000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		10000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte("")))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_DEFAULT, source)
 	assert.Equal(t, 10000, rate)
@@ -504,7 +504,7 @@ func TestMergeRemoteSettingWithLocalConfig(t *testing.T) {
 	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("OVERRIDE,SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte("")))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_FILE, source)
 	assert.Equal(t, 10000, rate)

--- a/v1/ao/internal/reporter/oboe_test.go
+++ b/v1/ao/internal/reporter/oboe_test.go
@@ -251,8 +251,8 @@ func TestSampleFlags(t *testing.T) {
 		{Type: "url", RegEx: `user\d{3}`, Tracing: config.DisabledTracingMode},
 		{Type: "url", Extensions: []string{".png", ".jpg"}, Tracing: config.DisabledTracingMode},
 	})
-	ok, _, _, _ = shouldTraceRequestWithURL(testLayer, false, "http://test.com/user123", false)
-	assert.False(t, ok)
+	decision := shouldTraceRequestWithURL(testLayer, false, "http://test.com/user123", false)
+	assert.False(t, decision.trace)
 
 	resetSettings()
 	c = globalSettingsCfg

--- a/v1/ao/internal/reporter/oboe_test.go
+++ b/v1/ao/internal/reporter/oboe_test.go
@@ -126,7 +126,7 @@ func TestSamplingRate(t *testing.T) {
 	// set 2.5% sampling rate
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		25000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
+		25000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
 
 	total := 100000
 	traced := callShouldTraceRequest(total, false)
@@ -169,14 +169,14 @@ func TestSampleRateBoundaries(t *testing.T) {
 	// check that max value doesn't go above 1000000
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000001, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000001, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
 
 	_, rate, _, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, 1000000, rate)
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		0, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
+		0, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
 
 	_, rate, _, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, 0, rate)
@@ -184,7 +184,7 @@ func TestSampleRateBoundaries(t *testing.T) {
 	// check that min value doesn't go below 0
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		-1, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
+		-1, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
 
 	_, rate, _, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, 0, rate)
@@ -205,14 +205,14 @@ func TestSampleSource(t *testing.T) {
 	// we're currently only looking up default settings, so this should return NONE sample source
 	updateSetting(int32(TYPE_LAYER), testLayer,
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
 	_, _, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_NONE, source)
 
 	// as soon as we add the default settings back, we get a valid sample source
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
 	_, _, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_DEFAULT, source)
 
@@ -225,7 +225,7 @@ func TestSampleFlags(t *testing.T) {
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte(""),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
 	ok, _, _, _ := shouldTraceRequest(testLayer, false)
 	assert.False(t, ok)
 	assert.EqualValues(t, 0, c.Through())
@@ -238,7 +238,7 @@ func TestSampleFlags(t *testing.T) {
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
 	ok, _, _, _ = shouldTraceRequest(testLayer, false)
 	assert.True(t, ok)
 	assert.EqualValues(t, 0, c.Through())
@@ -251,7 +251,7 @@ func TestSampleFlags(t *testing.T) {
 		{Type: "url", RegEx: `user\d{3}`, Tracing: config.DisabledTracingMode},
 		{Type: "url", Extensions: []string{".png", ".jpg"}, Tracing: config.DisabledTracingMode},
 	})
-	decision := shouldTraceRequestWithURL(testLayer, false, "http://test.com/user123", false)
+	decision := shouldTraceRequestWithURL(testLayer, false, "http://test.com/user123", ModeXTraceOptionsNotPresent)
 	assert.False(t, decision.trace)
 
 	resetSettings()
@@ -259,7 +259,7 @@ func TestSampleFlags(t *testing.T) {
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
 	ok, _, _, _ = shouldTraceRequest(testLayer, false)
 	assert.False(t, ok)
 	assert.EqualValues(t, 0, c.Through())
@@ -272,7 +272,7 @@ func TestSampleFlags(t *testing.T) {
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_THROUGH"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
 	ok, _, _, _ = shouldTraceRequest(testLayer, false)
 	assert.False(t, ok)
 	assert.EqualValues(t, 0, c.Through())
@@ -298,7 +298,7 @@ func TestSampleTokenBucket(t *testing.T) {
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START"),
-		1000000, 120, argsToMap(0, 0, 0, 0, -1, -1))
+		1000000, 120, argsToMap(0, 0, 0, 0, 0, 0, -1, -1))
 	traced = callShouldTraceRequest(1, false)
 	assert.EqualValues(t, 0, traced)
 	assert.EqualValues(t, 0, c.Traced())
@@ -310,7 +310,7 @@ func TestSampleTokenBucket(t *testing.T) {
 
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(16, 8, 16, 8, -1, -1))
+		1000000, 120, argsToMap(16, 8, 16, 8, 16, 8, -1, -1))
 	traced = callShouldTraceRequest(50, false)
 	assert.EqualValues(t, 16, traced)
 	assert.EqualValues(t, 16, c.Traced())
@@ -442,7 +442,7 @@ func TestMergeRemoteSettingWithLocalConfig(t *testing.T) {
 	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("OVERRIDE,SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_FILE, source)
 	assert.Equal(t, 10000, rate)
@@ -453,7 +453,7 @@ func TestMergeRemoteSettingWithLocalConfig(t *testing.T) {
 	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("OVERRIDE,SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_DEFAULT, source)
 	assert.Equal(t, 1000, rate)
@@ -464,7 +464,7 @@ func TestMergeRemoteSettingWithLocalConfig(t *testing.T) {
 	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_FILE, source)
 	assert.Equal(t, 10000, rate)
@@ -474,7 +474,7 @@ func TestMergeRemoteSettingWithLocalConfig(t *testing.T) {
 	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_FILE, source)
 	assert.Equal(t, 10000, rate)
@@ -484,7 +484,7 @@ func TestMergeRemoteSettingWithLocalConfig(t *testing.T) {
 	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("OVERRIDE,SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		10000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
+		10000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_DEFAULT, source)
 	assert.Equal(t, 10000, rate)
@@ -494,7 +494,7 @@ func TestMergeRemoteSettingWithLocalConfig(t *testing.T) {
 	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		10000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
+		10000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_DEFAULT, source)
 	assert.Equal(t, 10000, rate)
@@ -504,7 +504,7 @@ func TestMergeRemoteSettingWithLocalConfig(t *testing.T) {
 	_ = config.Load()
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("OVERRIDE,SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
 	trace, rate, source, _ = shouldTraceRequest(testLayer, false)
 	assert.Equal(t, SAMPLE_SOURCE_FILE, source)
 	assert.Equal(t, 10000, rate)

--- a/v1/ao/internal/reporter/reporter.go
+++ b/v1/ao/internal/reporter/reporter.go
@@ -160,13 +160,13 @@ func prepareEvent(ctx *oboeContext, e *event) error {
 	return nil
 }
 
-func shouldTraceRequestWithURL(layer string, traced bool, url string) (bool, int, sampleSource, bool) {
-	return oboeSampleRequest(layer, traced, url)
+func shouldTraceRequestWithURL(layer string, traced bool, url string, triggerTrace bool) (bool, int, sampleSource, bool) {
+	return oboeSampleRequest(layer, traced, url, triggerTrace)
 }
 
 // Determines if request should be traced, based on sample rate settings.
 func shouldTraceRequest(layer string, traced bool) (bool, int, sampleSource, bool) {
-	return shouldTraceRequestWithURL(layer, traced, "")
+	return shouldTraceRequestWithURL(layer, traced, "", false)
 }
 
 func argsToMap(capacity, ratePerSec float64, metricsFlushInterval, maxTransactions int) map[string][]byte {

--- a/v1/ao/internal/reporter/reporter.go
+++ b/v1/ao/internal/reporter/reporter.go
@@ -170,7 +170,7 @@ func shouldTraceRequest(layer string, traced bool) (bool, int, sampleSource, boo
 	return d.trace, d.rate, d.source, d.enabled
 }
 
-func argsToMap(capacity, ratePerSec float64, metricsFlushInterval, maxTransactions int) map[string][]byte {
+func argsToMap(capacity, ratePerSec, tCap, tRate float64, metricsFlushInterval, maxTransactions int) map[string][]byte {
 	args := make(map[string][]byte)
 
 	if capacity > -1 {
@@ -184,6 +184,18 @@ func argsToMap(capacity, ratePerSec float64, metricsFlushInterval, maxTransactio
 		bytes := make([]byte, 8)
 		binary.LittleEndian.PutUint64(bytes, bits)
 		args[kvBucketRate] = bytes
+	}
+	if tCap > -1 {
+		bits := math.Float64bits(capacity)
+		bytes := make([]byte, 8)
+		binary.LittleEndian.PutUint64(bytes, bits)
+		args[kvTriggerTraceBucketCapacity] = bytes
+	}
+	if tRate > -1 {
+		bits := math.Float64bits(tRate)
+		bytes := make([]byte, 8)
+		binary.LittleEndian.PutUint64(bytes, bits)
+		args[kvTriggerTraceBucketRate] = bytes
 	}
 	if metricsFlushInterval > -1 {
 		bytes := make([]byte, 4)

--- a/v1/ao/internal/reporter/reporter.go
+++ b/v1/ao/internal/reporter/reporter.go
@@ -174,7 +174,7 @@ func shouldTraceRequest(layer string, traced bool) (bool, int, sampleSource, boo
 }
 
 func argsToMap(capacity, ratePerSec, tRCap, tRRate, tSCap, tSRate float64,
-	metricsFlushInterval, maxTransactions int) map[string][]byte {
+	metricsFlushInterval, maxTransactions int, token []byte) map[string][]byte {
 	args := make(map[string][]byte)
 
 	if capacity > -1 {
@@ -223,6 +223,8 @@ func argsToMap(capacity, ratePerSec, tRCap, tRRate, tSCap, tSRate float64,
 		binary.LittleEndian.PutUint32(bytes, uint32(maxTransactions))
 		args[kvMaxTransactions] = bytes
 	}
+
+	args[kvTriggerToken] = token
 
 	return args
 }

--- a/v1/ao/internal/reporter/reporter.go
+++ b/v1/ao/internal/reporter/reporter.go
@@ -37,7 +37,7 @@ type reporter interface {
 
 // KVs from getSettingsResult arguments
 const (
-	kvTriggerToken                      = "TriggerToken"
+	kvSignatureKey                      = "SignatureKey"
 	kvBucketCapacity                    = "BucketCapacity"
 	kvBucketRate                        = "BucketRate"
 	kvTriggerTraceRelaxedBucketCapacity = "TriggerRelaxedBucketCapacity"
@@ -169,7 +169,7 @@ func shouldTraceRequestWithURL(layer string, traced bool, url string, triggerTra
 
 // Determines if request should be traced, based on sample rate settings.
 func shouldTraceRequest(layer string, traced bool) (bool, int, sampleSource, bool) {
-	d := shouldTraceRequestWithURL(layer, traced, "", ModeXTraceOptionsNotPresent)
+	d := shouldTraceRequestWithURL(layer, traced, "", ModeTriggerTraceNotPresent)
 	return d.trace, d.rate, d.source, d.enabled
 }
 
@@ -224,7 +224,7 @@ func argsToMap(capacity, ratePerSec, tRCap, tRRate, tSCap, tSRate float64,
 		args[kvMaxTransactions] = bytes
 	}
 
-	args[kvTriggerToken] = token
+	args[kvSignatureKey] = token
 
 	return args
 }

--- a/v1/ao/internal/reporter/reporter.go
+++ b/v1/ao/internal/reporter/reporter.go
@@ -160,13 +160,14 @@ func prepareEvent(ctx *oboeContext, e *event) error {
 	return nil
 }
 
-func shouldTraceRequestWithURL(layer string, traced bool, url string, triggerTrace bool) (bool, int, sampleSource, bool) {
+func shouldTraceRequestWithURL(layer string, traced bool, url string, triggerTrace bool) SampleDecision {
 	return oboeSampleRequest(layer, traced, url, triggerTrace)
 }
 
 // Determines if request should be traced, based on sample rate settings.
 func shouldTraceRequest(layer string, traced bool) (bool, int, sampleSource, bool) {
-	return shouldTraceRequestWithURL(layer, traced, "", false)
+	d := shouldTraceRequestWithURL(layer, traced, "", false)
+	return d.trace, d.rate, d.source, d.enabled
 }
 
 func argsToMap(capacity, ratePerSec float64, metricsFlushInterval, maxTransactions int) map[string][]byte {

--- a/v1/ao/internal/reporter/reporter.go
+++ b/v1/ao/internal/reporter/reporter.go
@@ -37,11 +37,13 @@ type reporter interface {
 
 // KVs from getSettingsResult arguments
 const (
-	kvBucketCapacity       = "BucketCapacity"
-	kvBucketRate           = "BucketRate"
-	kvMetricsFlushInterval = "MetricsFlushInterval"
-	kvEventsFlushInterval  = "EventsFlushInterval"
-	kvMaxTransactions      = "MaxTransactions"
+	kvBucketCapacity             = "BucketCapacity"
+	kvBucketRate                 = "BucketRate"
+	kvTriggerTraceBucketCapacity = "TriggerTraceBucketCapacity" // TODO: verify kv name
+	kvTriggerTraceBucketRate     = "TriggerTraceBucketRate"     // TODO: verify kv name
+	kvMetricsFlushInterval       = "MetricsFlushInterval"
+	kvEventsFlushInterval        = "EventsFlushInterval"
+	kvMaxTransactions            = "MaxTransactions"
 )
 
 // currently used reporter

--- a/v1/ao/internal/reporter/reporter.go
+++ b/v1/ao/internal/reporter/reporter.go
@@ -186,7 +186,7 @@ func argsToMap(capacity, ratePerSec, tCap, tRate float64, metricsFlushInterval, 
 		args[kvBucketRate] = bytes
 	}
 	if tCap > -1 {
-		bits := math.Float64bits(capacity)
+		bits := math.Float64bits(tCap)
 		bytes := make([]byte, 8)
 		binary.LittleEndian.PutUint64(bytes, bits)
 		args[kvTriggerTraceBucketCapacity] = bytes

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	grpcReporterVersion = "golang-v2"
+	grpcReporterVersion = "2"
 
 	// default certificate used to verify the collector endpoint,
 	// can be overridden via APPOPTICS_TRUSTEDPATH

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -825,7 +825,6 @@ func (r *grpcReporter) getSettings(ready chan bool) {
 // settings	new settings
 func (r *grpcReporter) updateSettings(settings *collector.SettingsResult) {
 	for _, s := range settings.GetSettings() {
-		log.Debugf("Got sampling setting: %#v\n", s.String())
 		updateSetting(int32(s.Type), string(s.Layer), s.Flags, s.Value, s.Ttl, s.Arguments)
 
 		// update MetricsFlushInterval

--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -774,7 +774,7 @@ func (r *grpcReporter) collectMetrics(collectReady chan bool) {
 	i := int(atomic.LoadInt32(&r.collectMetricInterval))
 	// generate a new metrics message
 	message := metrics.GenerateMetricsMessage(i, r.eventConnection.queueStats.CopyAndReset(),
-		globalSettingsCfg.FlushRateCounts())
+		FlushRateCounts())
 	r.sendMetrics(message)
 }
 

--- a/v1/ao/internal/reporter/reporter_udp.go
+++ b/v1/ao/internal/reporter/reporter_udp.go
@@ -42,7 +42,7 @@ func udpNewReporter() reporter {
 	// add default setting
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(16, 8, 16, 8, 16, 8, -1, -1))
+		1000000, 120, argsToMap(16, 8, 16, 8, 16, 8, -1, -1, []byte("")))
 
 	return &udpReporter{conn: conn}
 }

--- a/v1/ao/internal/reporter/reporter_udp.go
+++ b/v1/ao/internal/reporter/reporter_udp.go
@@ -42,7 +42,7 @@ func udpNewReporter() reporter {
 	// add default setting
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(16, 8, -1, -1))
+		1000000, 120, argsToMap(16, 8, 16, 8, -1, -1))
 
 	return &udpReporter{conn: conn}
 }

--- a/v1/ao/internal/reporter/reporter_udp.go
+++ b/v1/ao/internal/reporter/reporter_udp.go
@@ -42,7 +42,7 @@ func udpNewReporter() reporter {
 	// add default setting
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(16, 8, 16, 8, -1, -1))
+		1000000, 120, argsToMap(16, 8, 16, 8, 16, 8, -1, -1))
 
 	return &udpReporter{conn: conn}
 }

--- a/v1/ao/internal/reporter/test_reporter.go
+++ b/v1/ao/internal/reporter/test_reporter.go
@@ -212,7 +212,7 @@ func (r *TestReporter) reportSpan(span metrics.SpanMessage) error {
 func (r *TestReporter) addDefaultSetting() {
 	// add default setting with 100% sampling
 	updateSetting(int32(TYPE_DEFAULT), "",
-		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS,FORCE_TRACE"),
+		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS,TRIGGER_TRACE"),
 		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte(TestToken)))
 }
 
@@ -224,25 +224,25 @@ func (r *TestReporter) addNoTriggerTrace() {
 
 func (r *TestReporter) addTriggerTraceOnly() {
 	updateSetting(int32(TYPE_DEFAULT), "",
-		[]byte("FORCE_TRACE"),
+		[]byte("TRIGGER_TRACE"),
 		0, 120, argsToMap(0, 0, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte(TestToken)))
 }
 
 func (r *TestReporter) addRelaxedTriggerTraceOnly() {
 	updateSetting(int32(TYPE_DEFAULT), "",
-		[]byte("FORCE_TRACE"),
+		[]byte("TRIGGER_TRACE"),
 		0, 120, argsToMap(0, 0, 1000000, 1000000, 0, 0, -1, -1, []byte(TestToken)))
 }
 
 func (r *TestReporter) addStrictTriggerTraceOnly() {
 	updateSetting(int32(TYPE_DEFAULT), "",
-		[]byte("FORCE_TRACE"),
+		[]byte("TRIGGER_TRACE"),
 		0, 120, argsToMap(0, 0, 0, 0, 1000000, 1000000, -1, -1, []byte(TestToken)))
 }
 
 func (r *TestReporter) addLimitedTriggerTrace() {
 	updateSetting(int32(TYPE_DEFAULT), "",
-		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS,FORCE_TRACE"),
+		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS,TRIGGER_TRACE"),
 		1000000, 120, argsToMap(1000000, 1000000, 1, 1, 1, 1, -1, -1, []byte(TestToken)))
 }
 

--- a/v1/ao/internal/reporter/test_reporter.go
+++ b/v1/ao/internal/reporter/test_reporter.go
@@ -227,7 +227,7 @@ func (r *TestReporter) addTriggerTraceOnly() {
 
 func (r *TestReporter) addLimitedTriggerTrace() {
 	updateSetting(int32(TYPE_DEFAULT), "",
-		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
+		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS,FORCE_TRACE"),
 		1000000, 120, argsToMap(1000000, 1000000, 1, 1, -1, -1))
 }
 

--- a/v1/ao/internal/reporter/test_reporter.go
+++ b/v1/ao/internal/reporter/test_reporter.go
@@ -210,25 +210,37 @@ func (r *TestReporter) addDefaultSetting() {
 	// add default setting with 100% sampling
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS,FORCE_TRACE"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
 }
 
 func (r *TestReporter) addNoTriggerTrace() {
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, 0, 0, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 0, 0, 0, 0, -1, -1))
 }
 
 func (r *TestReporter) addTriggerTraceOnly() {
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("FORCE_TRACE"),
-		0, 120, argsToMap(0, 0, 1000000, 1000000, -1, -1))
+		0, 120, argsToMap(0, 0, 1000000, 1000000, 1000000, 1000000, -1, -1))
+}
+
+func (r *TestReporter) addRelaxedTriggerTraceOnly() {
+	updateSetting(int32(TYPE_DEFAULT), "",
+		[]byte("FORCE_TRACE"),
+		0, 120, argsToMap(0, 0, 1000000, 1000000, 0, 0, -1, -1))
+}
+
+func (r *TestReporter) addStrictTriggerTraceOnly() {
+	updateSetting(int32(TYPE_DEFAULT), "",
+		[]byte("FORCE_TRACE"),
+		0, 120, argsToMap(0, 0, 0, 0, 1000000, 1000000, -1, -1))
 }
 
 func (r *TestReporter) addLimitedTriggerTrace() {
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS,FORCE_TRACE"),
-		1000000, 120, argsToMap(1000000, 1000000, 1, 1, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1, 1, 1, 1, -1, -1))
 }
 
 // Setting types
@@ -236,6 +248,8 @@ const (
 	DefaultST = iota
 	NoTriggerTraceST
 	TriggerTraceOnlyST
+	RelaxedTriggerTraceOnlyST
+	StrictTriggerTraceOnlyST
 	LimitedTriggerTraceST
 	NoSettingST
 )
@@ -248,6 +262,10 @@ func (r *TestReporter) updateSetting() {
 		r.addNoTriggerTrace()
 	case TriggerTraceOnlyST:
 		r.addTriggerTraceOnly()
+	case RelaxedTriggerTraceOnlyST:
+		r.addRelaxedTriggerTraceOnly()
+	case StrictTriggerTraceOnlyST:
+		r.addStrictTriggerTraceOnly()
 	case LimitedTriggerTraceST:
 		r.addLimitedTriggerTrace()
 	case NoSettingST:

--- a/v1/ao/internal/reporter/test_reporter.go
+++ b/v1/ao/internal/reporter/test_reporter.go
@@ -31,7 +31,10 @@ type TestReporter struct {
 	Timeout        time.Duration
 }
 
-const defaultTestReporterTimeout = 2 * time.Second
+const (
+	defaultTestReporterTimeout = 2 * time.Second
+	TestToken                  = "TOKEN"
+)
 
 var usingTestReporter = false
 var oldReporter reporter = &nullReporter{}
@@ -210,37 +213,37 @@ func (r *TestReporter) addDefaultSetting() {
 	// add default setting with 100% sampling
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS,FORCE_TRACE"),
-		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte(TestToken)))
 }
 
 func (r *TestReporter) addNoTriggerTrace() {
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS"),
-		1000000, 120, argsToMap(1000000, 1000000, 0, 0, 0, 0, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 0, 0, 0, 0, -1, -1, []byte(TestToken)))
 }
 
 func (r *TestReporter) addTriggerTraceOnly() {
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("FORCE_TRACE"),
-		0, 120, argsToMap(0, 0, 1000000, 1000000, 1000000, 1000000, -1, -1))
+		0, 120, argsToMap(0, 0, 1000000, 1000000, 1000000, 1000000, -1, -1, []byte(TestToken)))
 }
 
 func (r *TestReporter) addRelaxedTriggerTraceOnly() {
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("FORCE_TRACE"),
-		0, 120, argsToMap(0, 0, 1000000, 1000000, 0, 0, -1, -1))
+		0, 120, argsToMap(0, 0, 1000000, 1000000, 0, 0, -1, -1, []byte(TestToken)))
 }
 
 func (r *TestReporter) addStrictTriggerTraceOnly() {
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("FORCE_TRACE"),
-		0, 120, argsToMap(0, 0, 0, 0, 1000000, 1000000, -1, -1))
+		0, 120, argsToMap(0, 0, 0, 0, 1000000, 1000000, -1, -1, []byte(TestToken)))
 }
 
 func (r *TestReporter) addLimitedTriggerTrace() {
 	updateSetting(int32(TYPE_DEFAULT), "",
 		[]byte("SAMPLE_START,SAMPLE_THROUGH_ALWAYS,FORCE_TRACE"),
-		1000000, 120, argsToMap(1000000, 1000000, 1, 1, 1, 1, -1, -1))
+		1000000, 120, argsToMap(1000000, 1000000, 1, 1, 1, 1, -1, -1, []byte(TestToken)))
 }
 
 // Setting types

--- a/v1/ao/layer.go
+++ b/v1/ao/layer.go
@@ -126,13 +126,7 @@ type SpanOptions struct {
 	// the impact on performance/memory footprint carefully.
 	WithBackTrace bool
 
-	MdStr string
-	// URL is used to do the URL-based transaction filtering.
-	URL string
-
-	TriggerTrace bool
-
-	CB func() KVMap
+	ContextOptions
 }
 
 // SpanOpt defines the function type that changes the SpanOptions

--- a/v1/ao/layer.go
+++ b/v1/ao/layer.go
@@ -125,8 +125,14 @@ type SpanOptions struct {
 	// `debug.Stack()` internally to gather the stack trace. Please consider
 	// the impact on performance/memory footprint carefully.
 	WithBackTrace bool
+
+	MdStr string
 	// URL is used to do the URL-based transaction filtering.
 	URL string
+
+	TriggerTrace bool
+
+	CB func() KVMap
 }
 
 // SpanOpt defines the function type that changes the SpanOptions

--- a/v1/ao/layer_test.go
+++ b/v1/ao/layer_test.go
@@ -194,7 +194,7 @@ func TestWithTransactionFiltering(t *testing.T) {
 
 	// 2. “disabled” transaction settings not matched
 	r = reporter.SetTestReporter()
-	tr = NewTraceWithOptions(layerName, SpanOptions{URL: "/eric"})
+	tr = NewTraceWithOptions(layerName, SpanOptions{false, ContextOptions{URL: "/eric"}})
 	tr.End()
 	r.Close(2)
 	assert.Equal(t, 2, len(r.EventBufs))
@@ -202,7 +202,7 @@ func TestWithTransactionFiltering(t *testing.T) {
 
 	// 3.1 “disabled” transaction settings matched
 	r = reporter.SetTestReporter()
-	tr = NewTraceWithOptions(layerName, SpanOptions{URL: "/test1"})
+	tr = NewTraceWithOptions(layerName, SpanOptions{false, ContextOptions{URL: "/test1"}})
 	tr.End()
 	r.Close(0)
 	assert.Equal(t, 0, len(r.EventBufs))
@@ -210,7 +210,7 @@ func TestWithTransactionFiltering(t *testing.T) {
 
 	// 3.2 “disabled” transaction settings matched
 	r = reporter.SetTestReporter()
-	tr = NewTraceWithOptions(layerName, SpanOptions{URL: "/eric.jpg"})
+	tr = NewTraceWithOptions(layerName, SpanOptions{false, ContextOptions{URL: "/eric.jpg"}})
 	tr.End()
 	r.Close(0)
 	assert.Equal(t, 0, len(r.EventBufs))
@@ -269,7 +269,7 @@ func TestWithTransactionFiltering(t *testing.T) {
 
 	// 9.“enabled” transaction settings not matched
 	r = reporter.SetTestReporter()
-	tr = NewTraceWithOptions(layerName, SpanOptions{URL: "/eric"})
+	tr = NewTraceWithOptions(layerName, SpanOptions{false, ContextOptions{URL: "/eric"}})
 	tr.End()
 	r.Close(0)
 	assert.Equal(t, 0, len(r.EventBufs))
@@ -277,7 +277,7 @@ func TestWithTransactionFiltering(t *testing.T) {
 
 	// 10.“enabled” transaction settings matching
 	r = reporter.SetTestReporter()
-	tr = NewTraceWithOptions(layerName, SpanOptions{URL: "/test1"})
+	tr = NewTraceWithOptions(layerName, SpanOptions{false, ContextOptions{URL: "/test1"}})
 	tr.End()
 	r.Close(2)
 	assert.Equal(t, 2, len(r.EventBufs))

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -359,11 +359,12 @@ func (t *aoTrace) LoggableTraceID() string {
 	return mdStr[2:42] + sampledFlag
 }
 
-// HTTPRspHeaders returns the headers which will be attached to the HTTP response
+// HTTPRspHeaders returns the headers which will be attached to the HTTP response.
 func (t *aoTrace) HTTPRspHeaders() map[string]string {
 	return t.httpRspHeaders
 }
 
+// SetHTTPRspHeaders attaches the headers map to the trace.
 func (t *aoTrace) SetHTTPRspHeaders(headers map[string]string) {
 	if t.httpRspHeaders == nil {
 		return

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -112,7 +112,7 @@ func NewTraceWithOptions(spanName string, opts SpanOptions) Trace {
 	if Disabled() || Closed() {
 		if opts.TriggerTrace.Enabled() && Disabled() {
 			return NewNullTraceWithHeaders(map[string]string{
-				HTTPHeaderXTraceOptionsResponse: "trigger_trace=trace-mode-disabled",
+				HTTPHeaderXTraceOptionsResponse: "trigger-trace=trace-mode-disabled",
 			})
 		} else {
 			return NewNullTrace()

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -69,6 +69,9 @@ type Trace interface {
 
 	// HTTPRspHeaders returns the headers for HTTP response
 	HTTPRspHeaders() map[string]string
+
+	// SetHTTPRspHeaders attach the headers to a trace
+	SetHTTPRspHeaders(map[string]string)
 }
 
 // KVMap is a map of additional key-value pairs to report along with the event data provided
@@ -138,7 +141,7 @@ func NewTraceWithOptions(spanName string, opts SpanOptions) Trace {
 		httpRspHeaders: make(map[string]string),
 	}
 	t.SetStartTime(time.Now())
-	t.setHTTPRspHeaders(headers)
+	t.SetHTTPRspHeaders(headers)
 	return t
 }
 
@@ -367,7 +370,7 @@ func (t *aoTrace) HTTPRspHeaders() map[string]string {
 	return t.httpRspHeaders
 }
 
-func (t *aoTrace) setHTTPRspHeaders(headers map[string]string) {
+func (t *aoTrace) SetHTTPRspHeaders(headers map[string]string) {
 	if t.httpRspHeaders == nil {
 		return
 	}
@@ -382,16 +385,17 @@ type nullTrace struct {
 	headers map[string]string
 }
 
-func (t *nullTrace) EndCallback(f func() KVMap)        {}
-func (t *nullTrace) ExitMetadata() string              { return "" }
-func (t *nullTrace) SetStartTime(start time.Time)      {}
-func (t *nullTrace) SetMethod(method string)           {}
-func (t *nullTrace) SetPath(path string)               {}
-func (t *nullTrace) SetHost(host string)               {}
-func (t *nullTrace) SetStatus(status int)              {}
-func (t *nullTrace) LoggableTraceID() string           { return "" }
-func (t *nullTrace) recordMetrics()                    {}
-func (t *nullTrace) HTTPRspHeaders() map[string]string { return t.headers }
+func (t *nullTrace) EndCallback(f func() KVMap)                  {}
+func (t *nullTrace) ExitMetadata() string                        { return "" }
+func (t *nullTrace) SetStartTime(start time.Time)                {}
+func (t *nullTrace) SetMethod(method string)                     {}
+func (t *nullTrace) SetPath(path string)                         {}
+func (t *nullTrace) SetHost(host string)                         {}
+func (t *nullTrace) SetStatus(status int)                        {}
+func (t *nullTrace) LoggableTraceID() string                     { return "" }
+func (t *nullTrace) recordMetrics()                              {}
+func (t *nullTrace) HTTPRspHeaders() map[string]string           { return t.headers }
+func (t *nullTrace) SetHTTPRspHeaders(headers map[string]string) { t.headers = headers }
 
 // NewNullTrace returns a trace that is not sampled.
 func NewNullTrace() Trace { return &nullTrace{} }

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -112,7 +112,7 @@ func NewTraceWithOptions(spanName string, opts SpanOptions) Trace {
 	if Disabled() || Closed() {
 		if opts.TriggerTrace && Disabled() {
 			return NewNullTraceWithHeaders(map[string]string{
-				"X-Trace-Options-Response": "force_trace=trace-mode-disabled",
+				"X-Trace-Options-Response": "trigger_trace=trace-mode-disabled",
 			})
 		} else {
 			return NewNullTrace()

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -375,9 +375,7 @@ func (t *aoTrace) SetHTTPRspHeaders(headers map[string]string) {
 }
 
 // A nullTrace is not tracing.
-type nullTrace struct {
-	nullSpan
-}
+type nullTrace struct{ nullSpan }
 
 func (t *nullTrace) EndCallback(f func() KVMap)                  {}
 func (t *nullTrace) ExitMetadata() string                        { return "" }

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -110,13 +110,7 @@ func NewTrace(spanName string) Trace {
 // NewTraceWithOptions creates a new trace with the provided options
 func NewTraceWithOptions(spanName string, opts SpanOptions) Trace {
 	if Disabled() || Closed() {
-		if opts.TriggerTrace.Enabled() && Disabled() {
-			return NewNullTraceWithHeaders(map[string]string{
-				HTTPHeaderXTraceOptionsResponse: "trigger-trace=trace-mode-disabled",
-			})
-		} else {
-			return NewNullTrace()
-		}
+		return NewNullTrace()
 	}
 
 	ctx, ok, headers := reporter.NewContext(spanName, true, opts.ContextOptions, func() KVMap {
@@ -399,6 +393,3 @@ func (t *nullTrace) SetHTTPRspHeaders(headers map[string]string) { t.headers = h
 
 // NewNullTrace returns a trace that is not sampled.
 func NewNullTrace() Trace { return &nullTrace{} }
-
-// NewNullTraceWithHeaders returns a null trace with the provided headers
-func NewNullTraceWithHeaders(headers map[string]string) Trace { return &nullTrace{headers: headers} }

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -110,7 +110,7 @@ func NewTrace(spanName string) Trace {
 // NewTraceWithOptions creates a new trace with the provided options
 func NewTraceWithOptions(spanName string, opts SpanOptions) Trace {
 	if Disabled() || Closed() {
-		if opts.TriggerTrace && Disabled() {
+		if opts.TriggerTrace.Enabled() && Disabled() {
 			return NewNullTraceWithHeaders(map[string]string{
 				HTTPHeaderXTraceOptionsResponse: "trigger_trace=trace-mode-disabled",
 			})

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -377,7 +377,6 @@ func (t *aoTrace) SetHTTPRspHeaders(headers map[string]string) {
 // A nullTrace is not tracing.
 type nullTrace struct {
 	nullSpan
-	headers map[string]string
 }
 
 func (t *nullTrace) EndCallback(f func() KVMap)                  {}
@@ -389,8 +388,8 @@ func (t *nullTrace) SetHost(host string)                         {}
 func (t *nullTrace) SetStatus(status int)                        {}
 func (t *nullTrace) LoggableTraceID() string                     { return "" }
 func (t *nullTrace) recordMetrics()                              {}
-func (t *nullTrace) HTTPRspHeaders() map[string]string           { return t.headers }
-func (t *nullTrace) SetHTTPRspHeaders(headers map[string]string) { t.headers = headers }
+func (t *nullTrace) HTTPRspHeaders() map[string]string           { return nil }
+func (t *nullTrace) SetHTTPRspHeaders(headers map[string]string) {}
 
 // NewNullTrace returns a trace that is not sampled.
 func NewNullTrace() Trace { return &nullTrace{} }

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -112,7 +112,7 @@ func NewTraceWithOptions(spanName string, opts SpanOptions) Trace {
 	if Disabled() || Closed() {
 		if opts.TriggerTrace && Disabled() {
 			return NewNullTraceWithHeaders(map[string]string{
-				"X-Trace-Options-Response": "trigger_trace=trace-mode-disabled",
+				HTTPHeaderXTraceOptionsResponse: "trigger_trace=trace-mode-disabled",
 			})
 		} else {
 			return NewNullTrace()

--- a/v1/ao/trigger_trace_test.go
+++ b/v1/ao/trigger_trace_test.go
@@ -1,0 +1,30 @@
+package ao_test
+
+import (
+	"testing"
+
+	g "github.com/appoptics/appoptics-apm-go/v1/ao/internal/graphtest"
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTriggerTrace(t *testing.T) {
+	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.DefaultST))
+	hd := map[string]string{
+		"X-Trace-Options": "trigger_trace;pd_keys=lo:se,check-id:123",
+	}
+
+	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
+	r.Close(2)
+	g.AssertGraph(t, r.EventBufs, 2, g.AssertNodeMap{
+		// entry event should have no edges
+		{"http.HandlerFunc", "entry"}: {Edges: g.Edges{}, Callback: func(n g.Node) {
+			assert.Equal(t, "test.com", n.Map["HTTP-Host"])
+		}},
+		{"http.HandlerFunc", "exit"}: {Edges: g.Edges{{"http.HandlerFunc", "entry"}}, Callback: func(n g.Node) {
+		}},
+	})
+	rHeader := rr.Header()
+	assert.EqualValues(t, "trigger_trace=ok", rHeader.Get("X-Trace-Options-Response"))
+	assert.NotEmpty(t, rHeader.Get("X-Trace"))
+}

--- a/v1/ao/trigger_trace_test.go
+++ b/v1/ao/trigger_trace_test.go
@@ -66,7 +66,7 @@ func TestSignedTriggerTraceNoSetting(t *testing.T) {
 	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
 	r.Close(0)
 	rHeader := rr.Header()
-	assert.EqualValues(t, "trigger-trace=settings-not-available;auth=bad-token", rHeader.Get("X-Trace-Options-Response"))
+	assert.EqualValues(t, "trigger-trace=settings-not-available;auth=no-signature-key", rHeader.Get("X-Trace-Options-Response"))
 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "00"))
 }
 

--- a/v1/ao/trigger_trace_test.go
+++ b/v1/ao/trigger_trace_test.go
@@ -16,7 +16,7 @@ import (
 func TestTriggerTrace(t *testing.T) {
 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.DefaultST))
 	hd := map[string]string{
-		"X-Trace-Options": "trigger_trace;pd_keys=lo:se,check-id:123",
+		"X-Trace-Options": "trigger-trace;pd-keys=lo:se,check-id:123",
 	}
 
 	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
@@ -30,7 +30,7 @@ func TestTriggerTrace(t *testing.T) {
 		}},
 	})
 	rHeader := rr.Header()
-	assert.EqualValues(t, "trigger_trace=ok", rHeader.Get("X-Trace-Options-Response"))
+	assert.EqualValues(t, "trigger-trace=ok", rHeader.Get("X-Trace-Options-Response"))
 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "01"))
 }
 
@@ -38,20 +38,20 @@ func TestTriggerTraceNoSetting(t *testing.T) {
 
 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.NoSettingST))
 	hd := map[string]string{
-		"X-Trace-Options": "trigger_trace;pd_keys=lo:se,check-id:123",
+		"X-Trace-Options": "trigger-trace;pd-keys=lo:se,check-id:123",
 	}
 
 	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
 	r.Close(0)
 	rHeader := rr.Header()
-	assert.EqualValues(t, "trigger_trace=settings-not-available", rHeader.Get("X-Trace-Options-Response"))
+	assert.EqualValues(t, "trigger-trace=settings-not-available", rHeader.Get("X-Trace-Options-Response"))
 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "00"))
 }
 
 func TestTriggerTraceWithCustomKey(t *testing.T) {
 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.TriggerTraceOnlyST))
 	hd := map[string]string{
-		"X-Trace-Options": "trigger_trace;custom_key1=value1",
+		"X-Trace-Options": "trigger-trace;custom-key1=value1",
 	}
 
 	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
@@ -59,20 +59,20 @@ func TestTriggerTraceWithCustomKey(t *testing.T) {
 	g.AssertGraph(t, r.EventBufs, 2, g.AssertNodeMap{
 		// entry event should have no edges
 		{"http.HandlerFunc", "entry"}: {Edges: g.Edges{}, Callback: func(n g.Node) {
-			assert.Equal(t, "value1", n.Map["custom_key1"])
+			assert.Equal(t, "value1", n.Map["custom-key1"])
 		}},
 		{"http.HandlerFunc", "exit"}: {Edges: g.Edges{{"http.HandlerFunc", "entry"}}, Callback: func(n g.Node) {
 		}},
 	})
 	rHeader := rr.Header()
-	assert.EqualValues(t, "trigger_trace=ok", rHeader.Get("X-Trace-Options-Response"))
+	assert.EqualValues(t, "trigger-trace=ok", rHeader.Get("X-Trace-Options-Response"))
 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "01"))
 }
 
 func TestTriggerTraceRateLimited(t *testing.T) {
 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.LimitedTriggerTraceST))
 	hd := map[string]string{
-		"X-Trace-Options": "trigger_trace;custom_key1=value1",
+		"X-Trace-Options": "trigger-trace;custom-key1=value1",
 	}
 
 	var rrs []*httptest.ResponseRecorder
@@ -91,9 +91,9 @@ func TestTriggerTraceRateLimited(t *testing.T) {
 
 	for _, rr := range rrs {
 		rsp := rr.Header().Get("X-Trace-Options-Response")
-		if rsp == "trigger_trace=ok" {
+		if rsp == "trigger-trace=ok" {
 			triggerTraced++
-		} else if rsp == "trigger_trace=rate-exceeded" {
+		} else if rsp == "trigger-trace=rate-exceeded" {
 			limited++
 		}
 	}
@@ -108,14 +108,14 @@ func TestTriggerTraceDisabled(t *testing.T) {
 
 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.DefaultST))
 	hd := map[string]string{
-		"X-Trace-Options": "trigger_trace;pd_keys=lo:se,check-id:123",
+		"X-Trace-Options": "trigger-trace;pd-keys=lo:se,check-id:123",
 	}
 
 	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
 	r.Close(0)
 
 	rHeader := rr.Header()
-	assert.EqualValues(t, "trigger_trace=disabled", rHeader.Get("X-Trace-Options-Response"))
+	assert.EqualValues(t, "trigger-trace=disabled", rHeader.Get("X-Trace-Options-Response"))
 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "00"))
 
 	_ = os.Unsetenv("APPOPTICS_TRIGGER_TRACE")
@@ -128,14 +128,14 @@ func TestTriggerTraceEnabledTracingModeDisabled(t *testing.T) {
 
 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.DefaultST))
 	hd := map[string]string{
-		"X-Trace-Options": "trigger_trace;pd_keys=lo:se,check-id:123",
+		"X-Trace-Options": "trigger-trace;pd-keys=lo:se,check-id:123",
 	}
 
 	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
 	r.Close(0)
 
 	rHeader := rr.Header()
-	assert.EqualValues(t, "trigger_trace=tracing-disabled", rHeader.Get("X-Trace-Options-Response"))
+	assert.EqualValues(t, "trigger-trace=tracing-disabled", rHeader.Get("X-Trace-Options-Response"))
 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "00"))
 
 	_ = os.Unsetenv("APPOPTICS_TRACING_MODE")
@@ -149,14 +149,14 @@ func TestTriggerTraceWithURLFiltering(t *testing.T) {
 
 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.DefaultST))
 	hd := map[string]string{
-		"X-Trace-Options": "trigger_trace;pd_keys=lo:se,check-id:123",
+		"X-Trace-Options": "trigger-trace;pd-keys=lo:se,check-id:123",
 	}
 
 	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
 	r.Close(0)
 
 	rHeader := rr.Header()
-	assert.EqualValues(t, "trigger_trace=tracing-disabled", rHeader.Get("X-Trace-Options-Response"))
+	assert.EqualValues(t, "trigger-trace=tracing-disabled", rHeader.Get("X-Trace-Options-Response"))
 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "00"))
 
 	reporter.ReloadURLsConfig(nil)
@@ -165,7 +165,7 @@ func TestTriggerTraceWithURLFiltering(t *testing.T) {
 func TestNoTriggerTrace(t *testing.T) {
 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.DefaultST))
 	hd := map[string]string{
-		"X-Trace-Options": "pd_keys=lo:se,check-id:123;custom_key1=value1",
+		"X-Trace-Options": "pd-keys=lo:se,check-id:123;custom-key1=value1",
 	}
 
 	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
@@ -174,7 +174,7 @@ func TestNoTriggerTrace(t *testing.T) {
 		// entry event should have no edges
 		{"http.HandlerFunc", "entry"}: {Edges: g.Edges{}, Callback: func(n g.Node) {
 			assert.Equal(t, "test.com", n.Map["HTTP-Host"])
-			assert.Equal(t, "value1", n.Map["custom_key1"])
+			assert.Equal(t, "value1", n.Map["custom-key1"])
 			assert.Equal(t, "lo:se,check-id:123", n.Map["PDKeys"])
 		}},
 		{"http.HandlerFunc", "exit"}: {Edges: g.Edges{{"http.HandlerFunc", "entry"}}, Callback: func(n g.Node) {
@@ -188,7 +188,7 @@ func TestNoTriggerTrace(t *testing.T) {
 func TestNoTriggerTraceInvalidFlag(t *testing.T) {
 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.DefaultST))
 	hd := map[string]string{
-		"X-Trace-Options": "trigger_trace=1;tigger_trace",
+		"X-Trace-Options": "trigger-trace=1;tigger_trace",
 	}
 
 	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
@@ -202,14 +202,14 @@ func TestNoTriggerTraceInvalidFlag(t *testing.T) {
 		}},
 	})
 	rHeader := rr.Header()
-	assert.EqualValues(t, "trigger-trace=not-requested;ignored=tigger_trace,trigger_trace", rHeader.Get("X-Trace-Options-Response"))
+	assert.EqualValues(t, "trigger-trace=not-requested;ignored=tigger_trace,trigger-trace", rHeader.Get("X-Trace-Options-Response"))
 	assert.NotEmpty(t, rHeader.Get("X-Trace"))
 }
 
 func TestTriggerTraceInvalidFlag(t *testing.T) {
 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.DefaultST))
 	hd := map[string]string{
-		"X-Trace-Options": "trigger_trace;foo=bar;app_id=123",
+		"X-Trace-Options": "trigger-trace;foo=bar;app_id=123",
 	}
 
 	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
@@ -223,28 +223,28 @@ func TestTriggerTraceInvalidFlag(t *testing.T) {
 		}},
 	})
 	rHeader := rr.Header()
-	assert.EqualValues(t, "trigger_trace=ok;ignored=foo,app_id", rHeader.Get("X-Trace-Options-Response"))
+	assert.EqualValues(t, "trigger-trace=ok;ignored=foo,app_id", rHeader.Get("X-Trace-Options-Response"))
 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "01"))
 }
 
 func TestTriggerTraceXTraceBothValid(t *testing.T) {
 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.DefaultST))
 	hd := map[string]string{
-		"X-Trace-Options": "trigger_trace",
+		"X-Trace-Options": "trigger-trace",
 		"X-Trace":         "2B987445277543FF9C151D0CDE6D29B6E21603D5DB2C5EFEA7749039AF00",
 	}
 
 	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
 	r.Close(0)
 	rHeader := rr.Header()
-	assert.EqualValues(t, "trigger_trace=ignored", rHeader.Get("X-Trace-Options-Response"))
+	assert.EqualValues(t, "trigger-trace=ignored", rHeader.Get("X-Trace-Options-Response"))
 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "00"))
 }
 
 func TestNoTriggerTraceXTrace(t *testing.T) {
 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.DefaultST))
 	hd := map[string]string{
-		"X-Trace-Options": "custom_key1=value1",
+		"X-Trace-Options": "custom-key1=value1",
 		"X-Trace":         "2B987445277543FF9C151D0CDE6D29B6E21603D5DB2C5EFEA7749039AF01",
 	}
 
@@ -254,7 +254,7 @@ func TestNoTriggerTraceXTrace(t *testing.T) {
 		// entry event should have no edges
 		{"http.HandlerFunc", "entry"}: {Edges: g.Edges{{"Edge", "2C5EFEA7749039AF"}}, Callback: func(n g.Node) {
 			assert.Equal(t, "test.com", n.Map["HTTP-Host"])
-			assert.Equal(t, "value1", n.Map["custom_key1"])
+			assert.Equal(t, "value1", n.Map["custom-key1"])
 		}},
 		{"http.HandlerFunc", "exit"}: {Edges: g.Edges{{"http.HandlerFunc", "entry"}}, Callback: func(n g.Node) {
 		}},
@@ -268,7 +268,7 @@ func TestNoTriggerTraceXTrace(t *testing.T) {
 func TestTriggerTraceInvalidXTrace(t *testing.T) {
 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.DefaultST))
 	hd := map[string]string{
-		"X-Trace-Options": "trigger_trace;pd_keys=lo:se,check-id:123",
+		"X-Trace-Options": "trigger-trace;pd-keys=lo:se,check-id:123",
 		"X-Trace":         "invalid-value",
 	}
 
@@ -283,14 +283,14 @@ func TestTriggerTraceInvalidXTrace(t *testing.T) {
 		}},
 	})
 	rHeader := rr.Header()
-	assert.EqualValues(t, "trigger_trace=ok", rHeader.Get("X-Trace-Options-Response"))
+	assert.EqualValues(t, "trigger-trace=ok", rHeader.Get("X-Trace-Options-Response"))
 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "01"))
 }
 
 // func TestRelaxedTriggerTrace(t *testing.T) {
 // 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.RelaxedTriggerTraceOnlyST))
 // 	hd := map[string]string{
-// 		"X-Trace-Options":           fmt.Sprintf("trigger_trace;pd_keys=lo:se,check-id:123;ts=%d", time.Now().Unix()),
+// 		"X-Trace-Options":           fmt.Sprintf("trigger-trace;pd-keys=lo:se,check-id:123;ts=%d", time.Now().Unix()),
 // 		"X-Trace-Options-Signature": "", // TODO:
 // 	}
 //
@@ -305,14 +305,14 @@ func TestTriggerTraceInvalidXTrace(t *testing.T) {
 // 		}},
 // 	})
 // 	rHeader := rr.Header()
-// 	assert.EqualValues(t, "trigger_trace=ok", rHeader.Get("X-Trace-Options-Response"))
+// 	assert.EqualValues(t, "trigger-trace=ok", rHeader.Get("X-Trace-Options-Response"))
 // 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "01"))
 // }
 
 // func TestRelaxedTriggerTraceTSTooEarly(t *testing.T) {
 // 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.RelaxedTriggerTraceOnlyST))
 // 	hd := map[string]string{
-// 		"X-Trace-Options":           fmt.Sprintf("trigger_trace;pd_keys=lo:se,check-id:123;ts=%d", time.Now().Unix()-60*6),
+// 		"X-Trace-Options":           fmt.Sprintf("trigger-trace;pd-keys=lo:se,check-id:123;ts=%d", time.Now().Unix()-60*6),
 // 		"X-Trace-Options-Signature": "", // TODO:
 // 	}
 //
@@ -327,14 +327,14 @@ func TestTriggerTraceInvalidXTrace(t *testing.T) {
 // 		}},
 // 	})
 // 	rHeader := rr.Header()
-// 	assert.EqualValues(t, "trigger_trace=not-requested", rHeader.Get("X-Trace-Options-Response"))
+// 	assert.EqualValues(t, "trigger-trace=not-requested", rHeader.Get("X-Trace-Options-Response"))
 // 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "00"))
 // }
 //
 // func TestRelaxedTriggerTraceInvalidSignature(t *testing.T) {
 // 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.RelaxedTriggerTraceOnlyST))
 // 	hd := map[string]string{
-// 		"X-Trace-Options":           fmt.Sprintf("trigger_trace;pd_keys=lo:se,check-id:123;ts=%d", time.Now().Unix()),
+// 		"X-Trace-Options":           fmt.Sprintf("trigger-trace;pd-keys=lo:se,check-id:123;ts=%d", time.Now().Unix()),
 // 		"X-Trace-Options-Signature": "", // TODO: invalid signature
 // 	}
 //
@@ -349,6 +349,6 @@ func TestTriggerTraceInvalidXTrace(t *testing.T) {
 // 		}},
 // 	})
 // 	rHeader := rr.Header()
-// 	assert.EqualValues(t, "trigger_trace=not-requested", rHeader.Get("X-Trace-Options-Response"))
+// 	assert.EqualValues(t, "trigger-trace=not-requested", rHeader.Get("X-Trace-Options-Response"))
 // 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "01"))
 // }

--- a/v1/ao/trigger_trace_test.go
+++ b/v1/ao/trigger_trace_test.go
@@ -1,8 +1,13 @@
 package ao_test
 
 import (
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/config"
 	g "github.com/appoptics/appoptics-apm-go/v1/ao/internal/graphtest"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
 	"github.com/stretchr/testify/assert"
@@ -26,5 +31,191 @@ func TestTriggerTrace(t *testing.T) {
 	})
 	rHeader := rr.Header()
 	assert.EqualValues(t, "trigger_trace=ok", rHeader.Get("X-Trace-Options-Response"))
+	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "01"))
+}
+
+func TestTriggerTraceNoSetting(t *testing.T) {
+
+	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.NoSettingST))
+	hd := map[string]string{
+		"X-Trace-Options": "trigger_trace;pd_keys=lo:se,check-id:123",
+	}
+
+	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
+	r.Close(0)
+	rHeader := rr.Header()
+	assert.EqualValues(t, "trigger_trace=settings-not-available", rHeader.Get("X-Trace-Options-Response"))
+	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "00"))
+}
+
+func TestTriggerTraceWithCustomKey(t *testing.T) {
+	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.TriggerTraceOnlyST))
+	hd := map[string]string{
+		"X-Trace-Options": "trigger_trace;custom_key1=value1",
+	}
+
+	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
+	r.Close(2)
+	g.AssertGraph(t, r.EventBufs, 2, g.AssertNodeMap{
+		// entry event should have no edges
+		{"http.HandlerFunc", "entry"}: {Edges: g.Edges{}, Callback: func(n g.Node) {
+			assert.Equal(t, "value1", n.Map["custom_key1"])
+		}},
+		{"http.HandlerFunc", "exit"}: {Edges: g.Edges{{"http.HandlerFunc", "entry"}}, Callback: func(n g.Node) {
+		}},
+	})
+	rHeader := rr.Header()
+	assert.EqualValues(t, "trigger_trace=ok", rHeader.Get("X-Trace-Options-Response"))
+	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "01"))
+}
+
+func TestTriggerTraceRateLimited(t *testing.T) {
+	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.LimitedTriggerTraceST))
+	hd := map[string]string{
+		"X-Trace-Options": "trigger_trace;custom_key1=value1",
+	}
+
+	var rrs []*httptest.ResponseRecorder
+	numRequests := 5
+	for i := 0; i < numRequests; i++ {
+		rrs = append(rrs, httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd))
+	}
+
+	r.Close(0) // Don't check number of events here
+
+	numEvts := len(r.EventBufs)
+	assert.True(t, numEvts < 10)
+
+	limited := 0
+	triggerTraced := 0
+
+	for _, rr := range rrs {
+		rsp := rr.Header().Get("X-Trace-Options-Response")
+		if rsp == "trigger_trace=ok" {
+			triggerTraced++
+		} else if rsp == "trigger_trace=rate-exceeded" {
+			limited++
+		}
+	}
+	assert.True(t, (limited+triggerTraced) == numRequests)
+	assert.True(t, triggerTraced*2 == numEvts,
+		fmt.Sprintf("triggerTraced=%d, numEvts=%d", triggerTraced, numEvts))
+}
+
+func TestTriggerTraceDisabled(t *testing.T) {
+	_ = os.Setenv("APPOPTICS_TRIGGER_TRACE", "false")
+	_ = config.Load()
+
+	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.DefaultST))
+	hd := map[string]string{
+		"X-Trace-Options": "trigger_trace;pd_keys=lo:se,check-id:123",
+	}
+
+	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
+	r.Close(0)
+
+	rHeader := rr.Header()
+	assert.EqualValues(t, "trigger_trace=disabled", rHeader.Get("X-Trace-Options-Response"))
+	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "00"))
+
+	_ = os.Unsetenv("APPOPTICS_TRIGGER_TRACE")
+	_ = config.Load()
+}
+
+func TestTriggerTraceEnabledTracingModeDisabled(t *testing.T) {
+	_ = os.Setenv("APPOPTICS_TRACING_MODE", "disabled")
+	_ = config.Load()
+
+	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.DefaultST))
+	hd := map[string]string{
+		"X-Trace-Options": "trigger_trace;pd_keys=lo:se,check-id:123",
+	}
+
+	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
+	r.Close(0)
+
+	rHeader := rr.Header()
+	assert.EqualValues(t, "trigger_trace=tracing-disabled", rHeader.Get("X-Trace-Options-Response"))
+	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "00"))
+
+	_ = os.Unsetenv("APPOPTICS_TRACING_MODE")
+	_ = config.Load()
+}
+
+func TestNoTriggerTrace(t *testing.T) {
+	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.DefaultST))
+	hd := map[string]string{
+		"X-Trace-Options": "pd_keys=lo:se,check-id:123;custom_key1=value1",
+	}
+
+	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
+	r.Close(2)
+	g.AssertGraph(t, r.EventBufs, 2, g.AssertNodeMap{
+		// entry event should have no edges
+		{"http.HandlerFunc", "entry"}: {Edges: g.Edges{}, Callback: func(n g.Node) {
+			assert.Equal(t, "test.com", n.Map["HTTP-Host"])
+			assert.Equal(t, "value1", n.Map["custom_key1"])
+		}},
+		{"http.HandlerFunc", "exit"}: {Edges: g.Edges{{"http.HandlerFunc", "entry"}}, Callback: func(n g.Node) {
+		}},
+	})
+	rHeader := rr.Header()
+	assert.Empty(t, rHeader.Get("X-Trace-Options-Response"))
 	assert.NotEmpty(t, rHeader.Get("X-Trace"))
+}
+
+func TestNoTriggerTraceInvalidFlag(t *testing.T) {
+	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.DefaultST))
+	hd := map[string]string{
+		"X-Trace-Options": "trigger_trace=1;tigger_trace",
+	}
+
+	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
+	r.Close(2)
+	g.AssertGraph(t, r.EventBufs, 2, g.AssertNodeMap{
+		// entry event should have no edges
+		{"http.HandlerFunc", "entry"}: {Edges: g.Edges{}, Callback: func(n g.Node) {
+			assert.Equal(t, "test.com", n.Map["HTTP-Host"])
+		}},
+		{"http.HandlerFunc", "exit"}: {Edges: g.Edges{{"http.HandlerFunc", "entry"}}, Callback: func(n g.Node) {
+		}},
+	})
+	rHeader := rr.Header()
+	assert.EqualValues(t, "ignored=tigger_trace,trigger_trace", rHeader.Get("X-Trace-Options-Response"))
+	assert.NotEmpty(t, rHeader.Get("X-Trace"))
+}
+
+func TestTriggerTraceInvalidFlag(t *testing.T) {
+	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.DefaultST))
+	hd := map[string]string{
+		"X-Trace-Options": "trigger_trace;foo=bar;app_id=123",
+	}
+
+	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
+	r.Close(2)
+	g.AssertGraph(t, r.EventBufs, 2, g.AssertNodeMap{
+		// entry event should have no edges
+		{"http.HandlerFunc", "entry"}: {Edges: g.Edges{}, Callback: func(n g.Node) {
+			assert.Equal(t, "test.com", n.Map["HTTP-Host"])
+		}},
+		{"http.HandlerFunc", "exit"}: {Edges: g.Edges{{"http.HandlerFunc", "entry"}}, Callback: func(n g.Node) {
+		}},
+	})
+	rHeader := rr.Header()
+	assert.EqualValues(t, "trigger_trace=ok;ignored=foo,app_id", rHeader.Get("X-Trace-Options-Response"))
+	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "01"))
+}
+
+func TestTriggerTraceXTraceBothValid(t *testing.T) {
+	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.DefaultST))
+	hd := map[string]string{
+		"X-Trace-Options": "trigger_trace",
+		"X-Trace":         "2B987445277543FF9C151D0CDE6D29B6E21603D5DB2C5EFEA7749039AF00",
+	}
+
+	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
+	r.Close(0)
+	rHeader := rr.Header()
+	assert.EqualValues(t, "trigger_trace=ignored", rHeader.Get("X-Trace-Options-Response"))
+	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "00"))
 }

--- a/v1/ao/trigger_trace_test.go
+++ b/v1/ao/trigger_trace_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/config"
 	g "github.com/appoptics/appoptics-apm-go/v1/ao/internal/graphtest"
@@ -287,33 +288,37 @@ func TestTriggerTraceInvalidXTrace(t *testing.T) {
 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "01"))
 }
 
-// func TestRelaxedTriggerTrace(t *testing.T) {
-// 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.RelaxedTriggerTraceOnlyST))
-// 	hd := map[string]string{
-// 		"X-Trace-Options":           fmt.Sprintf("trigger-trace;pd-keys=lo:se,check-id:123;ts=%d", time.Now().Unix()),
-// 		"X-Trace-Options-Signature": "", // TODO:
-// 	}
-//
-// 	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
-// 	r.Close(2)
-// 	g.AssertGraph(t, r.EventBufs, 2, g.AssertNodeMap{
-// 		// entry event should have no edges
-// 		{"http.HandlerFunc", "entry"}: {Edges: g.Edges{}, Callback: func(n g.Node) {
-// 			assert.Equal(t, "test.com", n.Map["HTTP-Host"])
-// 		}},
-// 		{"http.HandlerFunc", "exit"}: {Edges: g.Edges{{"http.HandlerFunc", "entry"}}, Callback: func(n g.Node) {
-// 		}},
-// 	})
-// 	rHeader := rr.Header()
-// 	assert.EqualValues(t, "trigger-trace=ok", rHeader.Get("X-Trace-Options-Response"))
-// 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "01"))
-// }
+func TestRelaxedTriggerTrace(t *testing.T) {
+	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.RelaxedTriggerTraceOnlyST))
+	ts := time.Now().Unix()
+	opts := fmt.Sprintf("trigger-trace;pd-keys=lo:se,check-id:123;ts=%d", ts)
+	hd := map[string]string{
+		"X-Trace-Options":           opts,
+		"X-Trace-Options-Signature": reporter.HmacHash([]byte(reporter.TestToken), []byte(opts)), // TODO:
+	}
+
+	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
+	r.Close(2)
+	g.AssertGraph(t, r.EventBufs, 2, g.AssertNodeMap{
+		// entry event should have no edges
+		{"http.HandlerFunc", "entry"}: {Edges: g.Edges{}, Callback: func(n g.Node) {
+			assert.Equal(t, "test.com", n.Map["HTTP-Host"])
+		}},
+		{"http.HandlerFunc", "exit"}: {Edges: g.Edges{{"http.HandlerFunc", "entry"}}, Callback: func(n g.Node) {
+		}},
+	})
+	rHeader := rr.Header()
+	assert.EqualValues(t, "trigger-trace=ok", rHeader.Get("X-Trace-Options-Response"))
+	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "01"))
+}
 
 // func TestRelaxedTriggerTraceTSTooEarly(t *testing.T) {
 // 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.RelaxedTriggerTraceOnlyST))
+// 	ts := time.Now().Unix() - 60*6
+// 	opts := fmt.Sprintf("trigger-trace;pd-keys=lo:se,check-id:123;ts=%d", ts)
 // 	hd := map[string]string{
-// 		"X-Trace-Options":           fmt.Sprintf("trigger-trace;pd-keys=lo:se,check-id:123;ts=%d", time.Now().Unix()-60*6),
-// 		"X-Trace-Options-Signature": "", // TODO:
+// 		"X-Trace-Options":           opts,
+// 		"X-Trace-Options-Signature": reporter.HmacHash([]byte(reporter.TestToken), []byte(opts)), // TODO:
 // 	}
 //
 // 	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
@@ -335,7 +340,7 @@ func TestTriggerTraceInvalidXTrace(t *testing.T) {
 // 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.RelaxedTriggerTraceOnlyST))
 // 	hd := map[string]string{
 // 		"X-Trace-Options":           fmt.Sprintf("trigger-trace;pd-keys=lo:se,check-id:123;ts=%d", time.Now().Unix()),
-// 		"X-Trace-Options-Signature": "", // TODO: invalid signature
+// 		"X-Trace-Options-Signature": "invalidSignature", // TODO: invalid signature
 // 	}
 //
 // 	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)

--- a/v1/ao/trigger_trace_test.go
+++ b/v1/ao/trigger_trace_test.go
@@ -178,7 +178,7 @@ func TestTriggerTraceLocalDisabledRemoteEnabled(t *testing.T) {
 	r.Close(0)
 
 	rHeader := rr.Header()
-	assert.EqualValues(t, "trigger-trace=disabled", rHeader.Get("X-Trace-Options-Response"))
+	assert.EqualValues(t, "trigger-trace=trigger-tracing-disabled", rHeader.Get("X-Trace-Options-Response"))
 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "00"))
 
 	_ = os.Unsetenv("APPOPTICS_TRIGGER_TRACE")
@@ -199,7 +199,7 @@ func TestTriggerTraceLocalEnabledRemoteDisabled(t *testing.T) {
 	r.Close(0)
 
 	rHeader := rr.Header()
-	assert.EqualValues(t, "trigger-trace=disabled", rHeader.Get("X-Trace-Options-Response"))
+	assert.EqualValues(t, "trigger-trace=trigger-tracing-disabled", rHeader.Get("X-Trace-Options-Response"))
 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "00"))
 
 	_ = os.Unsetenv("APPOPTICS_TRIGGER_TRACE")

--- a/v1/ao/trigger_trace_test.go
+++ b/v1/ao/trigger_trace_test.go
@@ -286,3 +286,69 @@ func TestTriggerTraceInvalidXTrace(t *testing.T) {
 	assert.EqualValues(t, "trigger_trace=ok", rHeader.Get("X-Trace-Options-Response"))
 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "01"))
 }
+
+// func TestRelaxedTriggerTrace(t *testing.T) {
+// 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.RelaxedTriggerTraceOnlyST))
+// 	hd := map[string]string{
+// 		"X-Trace-Options":           fmt.Sprintf("trigger_trace;pd_keys=lo:se,check-id:123;ts=%d", time.Now().Unix()),
+// 		"X-Trace-Options-Signature": "", // TODO:
+// 	}
+//
+// 	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
+// 	r.Close(2)
+// 	g.AssertGraph(t, r.EventBufs, 2, g.AssertNodeMap{
+// 		// entry event should have no edges
+// 		{"http.HandlerFunc", "entry"}: {Edges: g.Edges{}, Callback: func(n g.Node) {
+// 			assert.Equal(t, "test.com", n.Map["HTTP-Host"])
+// 		}},
+// 		{"http.HandlerFunc", "exit"}: {Edges: g.Edges{{"http.HandlerFunc", "entry"}}, Callback: func(n g.Node) {
+// 		}},
+// 	})
+// 	rHeader := rr.Header()
+// 	assert.EqualValues(t, "trigger_trace=ok", rHeader.Get("X-Trace-Options-Response"))
+// 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "01"))
+// }
+
+// func TestRelaxedTriggerTraceTSTooEarly(t *testing.T) {
+// 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.RelaxedTriggerTraceOnlyST))
+// 	hd := map[string]string{
+// 		"X-Trace-Options":           fmt.Sprintf("trigger_trace;pd_keys=lo:se,check-id:123;ts=%d", time.Now().Unix()-60*6),
+// 		"X-Trace-Options-Signature": "", // TODO:
+// 	}
+//
+// 	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
+// 	r.Close(2)
+// 	g.AssertGraph(t, r.EventBufs, 2, g.AssertNodeMap{
+// 		// entry event should have no edges
+// 		{"http.HandlerFunc", "entry"}: {Edges: g.Edges{}, Callback: func(n g.Node) {
+// 			assert.Equal(t, "test.com", n.Map["HTTP-Host"])
+// 		}},
+// 		{"http.HandlerFunc", "exit"}: {Edges: g.Edges{{"http.HandlerFunc", "entry"}}, Callback: func(n g.Node) {
+// 		}},
+// 	})
+// 	rHeader := rr.Header()
+// 	assert.EqualValues(t, "trigger_trace=not-requested", rHeader.Get("X-Trace-Options-Response"))
+// 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "00"))
+// }
+//
+// func TestRelaxedTriggerTraceInvalidSignature(t *testing.T) {
+// 	r := reporter.SetTestReporter(reporter.TestReporterSettingType(reporter.RelaxedTriggerTraceOnlyST))
+// 	hd := map[string]string{
+// 		"X-Trace-Options":           fmt.Sprintf("trigger_trace;pd_keys=lo:se,check-id:123;ts=%d", time.Now().Unix()),
+// 		"X-Trace-Options-Signature": "", // TODO: invalid signature
+// 	}
+//
+// 	rr := httpTestWithEndpointWithHeaders(handler200, "http://test.com/hello", hd)
+// 	r.Close(2)
+// 	g.AssertGraph(t, r.EventBufs, 2, g.AssertNodeMap{
+// 		// entry event should have no edges
+// 		{"http.HandlerFunc", "entry"}: {Edges: g.Edges{}, Callback: func(n g.Node) {
+// 			assert.Equal(t, "test.com", n.Map["HTTP-Host"])
+// 		}},
+// 		{"http.HandlerFunc", "exit"}: {Edges: g.Edges{{"http.HandlerFunc", "entry"}}, Callback: func(n g.Node) {
+// 		}},
+// 	})
+// 	rHeader := rr.Header()
+// 	assert.EqualValues(t, "trigger_trace=not-requested", rHeader.Get("X-Trace-Options-Response"))
+// 	assert.True(t, strings.HasSuffix(rHeader.Get("X-Trace"), "01"))
+// }

--- a/v1/contrib/aogrpc/interceptors.go
+++ b/v1/contrib/aogrpc/interceptors.go
@@ -79,7 +79,8 @@ func tracingContext(ctx context.Context, serverName string, methodName string, s
 		}
 	}
 
-	triggerTrace, triggerTraceKVs := ao.CheckTriggerTraceHeader(md)
+	// TODO: attach headers to HTTP response
+	triggerTrace, triggerTraceKVs, _ := ao.CheckTriggerTraceHeader(md)
 
 	t := ao.NewTraceWithOptions(serverName, ao.SpanOptions{
 		ContextOptions: ao.ContextOptions{

--- a/v1/contrib/aogrpc/interceptors.go
+++ b/v1/contrib/aogrpc/interceptors.go
@@ -80,7 +80,7 @@ func tracingContext(ctx context.Context, serverName string, methodName string, s
 	}
 
 	// TODO: attach headers to HTTP response
-	triggerTrace, triggerTraceKVs, _ := ao.CheckTriggerTraceHeader(md)
+	triggerTrace, triggerTraceKVs, _, _ := ao.CheckTriggerTraceHeader(md)
 
 	t := ao.NewTraceWithOptions(serverName, ao.SpanOptions{
 		ContextOptions: ao.ContextOptions{

--- a/v1/contrib/aogrpc/interceptors.go
+++ b/v1/contrib/aogrpc/interceptors.go
@@ -80,7 +80,7 @@ func tracingContext(ctx context.Context, serverName string, methodName string, s
 	}
 
 	// TODO: attach headers to HTTP response
-	triggerTrace, triggerTraceKVs, _, _ := ao.CheckTriggerTraceHeader(md)
+	triggerTrace, triggerTraceKVs, _ := ao.CheckTriggerTraceHeader(md)
 
 	t := ao.NewTraceWithOptions(serverName, ao.SpanOptions{
 		ContextOptions: ao.ContextOptions{

--- a/v1/contrib/aogrpc/interceptors.go
+++ b/v1/contrib/aogrpc/interceptors.go
@@ -82,25 +82,25 @@ func tracingContext(ctx context.Context, serverName string, methodName string, s
 	triggerTrace, triggerTraceKVs := ao.CheckTriggerTraceHeader(md)
 
 	t := ao.NewTraceWithOptions(serverName, ao.SpanOptions{
-		WithBackTrace: false,
-		MdStr:         xtID,
-		URL:           methodName,
-		TriggerTrace:  triggerTrace,
-		CB: func() ao.KVMap {
-			kvs := ao.KVMap{
-				"Method":     "POST",
-				"Controller": serverName,
-				"Action":     action,
-				"URL":        methodName,
-				"Status":     statusCode,
-			}
+		ContextOptions: ao.ContextOptions{
+			MdStr:        xtID,
+			URL:          methodName,
+			TriggerTrace: triggerTrace,
+			CB: func() ao.KVMap {
+				kvs := ao.KVMap{
+					"Method":     "POST",
+					"Controller": serverName,
+					"Action":     action,
+					"URL":        methodName,
+					"Status":     statusCode,
+				}
 
-			for k, v := range triggerTraceKVs {
-				kvs[k] = v
-			}
-			return kvs
-		},
-	})
+				for k, v := range triggerTraceKVs {
+					kvs[k] = v
+				}
+				return kvs
+			},
+		}})
 
 	t.SetMethod("POST")
 	t.SetTransactionName(serverName + "." + action)


### PR DESCRIPTION
Added support for headers `X-Trace-Options/X-Trace-Options-Signature` to let users trigger a trace explicitly. 

See https://swicloud.atlassian.net/browse/AO-13526 for mode details.