### PR TITLE
AO-13872: Accept enabled/disabled as valid bool values in env vars and config files

### DIFF
--- a/v1/ao/internal/config/env.go
+++ b/v1/ao/internal/config/env.go
@@ -15,9 +15,9 @@ import (
 
 func toBool(s string) (bool, error) {
 	s = strings.ToLower(strings.TrimSpace(s))
-	if s == "yes" || s == "true" {
+	if s == "yes" || s == "true" || s == "enabled" {
 		return true, nil
-	} else if s == "no" || s == "false" {
+	} else if s == "no" || s == "false" || s == "disabled" {
 		return false, nil
 	}
 	return false, errors.New("cannot convert input to bool")

--- a/v1/ao/internal/config/env_test.go
+++ b/v1/ao/internal/config/env_test.go
@@ -10,7 +10,15 @@ import (
 )
 
 func TestToBool(t *testing.T) {
-	b, err := toBool("yes")
+	b, err := toBool("enabled")
+	assert.True(t, b)
+	assert.Nil(t, err)
+
+	b, err = toBool("disabled")
+	assert.False(t, b)
+	assert.Nil(t, err)
+
+	b, err = toBool("yes")
 	assert.True(t, b)
 	assert.Nil(t, err)
 

--- a/v1/ao/internal/utils/version.go
+++ b/v1/ao/internal/utils/version.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	// The AppOptics Go agent version
-	version = "1.8.1"
+	version = "1.9.0"
 
 	// The Go version
 	goVersion = strings.TrimPrefix(runtime.Version(), "go")


### PR DESCRIPTION
This PR proposes the change that accepts `enabled` and `disabled` as legit values for boolean configuration items in env vars and config files. This makes the env vars more consistent across agents.

See also: https://swicloud.atlassian.net/browse/AO-13872 for more details.