### PR TITLE
AO-13646: Clean up legacy profile from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,19 +127,15 @@ To monitor more than just the overall latency of each request to your Go service
 break a request's processing time down by placing small benchmarks into your code. To do so, first
 start or continue a `Trace` (the root `Span`), then create a series of `Span`s to capture the time used by different parts of the app's stack as it is processed.
 
-AppOptics provides two ways of measuring time spent by your code: a `Span` can measure e.g. a
+AppOptics provides a way to measure time spent by your code: a `Span` can measure e.g. a
 single DB query or cache request, an outgoing HTTP or RPC request, the entire time spent within a
-controller method, or the time used by a middleware method between calls to child Spans. A
-`Profile` is a special type of `Span` providing a named measurement of time spent and is typically used to
-measure a single function call or code block, e.g. to represent the time used by expensive
-computation(s) occurring in a `Span`. Spans can be created as children of other Spans, but a
-`Profile` cannot have children.
+controller method, or the time used by a middleware method between calls to child Spans. Spans can be created
+ as children of other Spans.
 
 AppOptics identifies a reported Span's type from its key-value pairs; if keys named "Query" and
 "RemoteHost" are used, a Span is assumed to measure the extent of a DB query. KV pairs can be
-appended to Spans and Profiles as optional extra variadic arguments to methods such as
+appended to Spans as optional extra variadic arguments to methods such as
 [BeginSpan()](https://godoc.org/github.com/appoptics/appoptics-apm-go/v1/ao#BeginSpan) or
-[BeginProfile()](https://godoc.org/github.com/appoptics/appoptics-apm-go/v1/ao#BeginProfile),
 [Info()](https://godoc.org/github.com/appoptics/appoptics-apm-go/v1/ao#Span), and
 [End()](https://godoc.org/github.com/appoptics/appoptics-apm-go/v1/ao#Span). We also provide helper methods
 such as [BeginQuerySpan()](https://godoc.org/github.com/appoptics/appoptics-apm-go/v1/ao#BeginQuerySpan),
@@ -153,19 +149,10 @@ to report attributes associated with different types of service calls, used for 
 filterable charts and latency heatmaps.
 
 ```go
-func slowFunc(ctx context.Context) {
-    // profile a slow function call
-    defer ao.BeginProfile(ctx, "slowFunc").End()
-    // ... do something slow
-}
-
 func myHandler(ctx context.Context) {
     // create new ao.Span and context.Context for this part of the request
     L, ctxL := ao.BeginSpan(ctx, "myHandler")
     defer L.End()
-
-    // profile a slow part of this ao.Span
-    slowFunc(ctxL)
 
     // Start a new Span, given a parent span
     mL, _ := L.BeginSpan("myMiddleware")
@@ -280,9 +267,8 @@ new Span and an associated context, and
 defined in the provided context.
 
 It is not required to work with context.Context to trace your app, however. You can also use just
-the [Trace](https://godoc.org/github.com/appoptics/appoptics-apm-go/v1/ao#Trace),
-[Span](https://godoc.org/github.com/appoptics/appoptics-apm-go/v1/ao#Span), and
-[Profile](https://godoc.org/github.com/appoptics/appoptics-apm-go/v1/ao#Profile) interfaces directly, if it
+the [Trace](https://godoc.org/github.com/appoptics/appoptics-apm-go/v1/ao#Trace) and
+[Span](https://godoc.org/github.com/appoptics/appoptics-apm-go/v1/ao#Span) interfaces directly, if it
 better suits your instrumentation use case.
 
 ```go

--- a/v1/ao/internal/reporter/event.go
+++ b/v1/ao/internal/reporter/event.go
@@ -23,7 +23,7 @@ type event struct {
 // Label is a required event attribute.
 type Label string
 
-// Labels used for reporting events for Layer and Profile spans.
+// Labels used for reporting events for Layer spans.
 const (
 	LabelEntry = "entry"
 	LabelExit  = "exit"

--- a/v1/ao/layer.go
+++ b/v1/ao/layer.go
@@ -32,7 +32,6 @@ const (
 	keyErrorMsg        = "ErrorMsg"
 	keyAsync           = "Async"
 	keyLanguage        = "Language"
-	keyProfileName     = "ProfileName"
 	keyFunctionName    = "FunctionName"
 	keyFile            = "File"
 	keyLineNumber      = "LineNumber"

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -25,7 +25,6 @@ const (
 type Trace interface {
 	// Span inherited from the Span interface
 	// BeginSpan(spanName string, args ...interface{}) Span
-	// BeginProfile(profileName string, args ...interface{}) Profile
 	// End(args ...interface{})
 	// Info(args ...interface{})
 	// Error(class, msg string)


### PR DESCRIPTION
Clean up the leftovers from the README regarding the legacy `Profile`.

See https://swicloud.atlassian.net/browse/AO-13646