### PR TITLE
AO-14101: [logging] logger improvements

### DIFF
--- a/v1/ao/agent.go
+++ b/v1/ao/agent.go
@@ -4,9 +4,10 @@ package ao
 
 import (
 	"context"
+	"io"
 
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/config"
-	aolog "github.com/appoptics/appoptics-apm-go/v1/ao/internal/log"
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/log"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
 	"github.com/pkg/errors"
 )
@@ -35,7 +36,7 @@ func init() {
 func initDisabled() {
 	disabled = config.GetDisabled()
 	if disabled {
-		aolog.Warningf("AppOptics agent is disabled.")
+		log.Warningf("AppOptics agent is disabled.")
 	}
 }
 
@@ -76,15 +77,20 @@ func Closed() bool {
 // SetLogLevel changes the logging level of the AppOptics agent
 // Valid logging levels: DEBUG, INFO, WARN, ERROR
 func SetLogLevel(level string) error {
-	l, ok := aolog.ToLogLevel(level)
+	l, ok := log.ToLogLevel(level)
 	if !ok {
 		return errInvalidLogLevel
 	}
-	aolog.SetLevel(l)
+	log.SetLevel(l)
 	return nil
 }
 
 // GetLogLevel returns the current logging level of the AppOptics agent
 func GetLogLevel() string {
-	return aolog.LevelStr[aolog.Level()]
+	return log.LevelStr[log.Level()]
+}
+
+// SetLogOutput sets the output destination for the internal logger.
+func SetLogOutput(w io.Writer) {
+	log.SetOutput(w)
 }

--- a/v1/ao/agent_test.go
+++ b/v1/ao/agent_test.go
@@ -3,10 +3,14 @@
 package ao
 
 import (
+	"bytes"
 	"context"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/log"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,4 +36,19 @@ func TestShutdown(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Hour*24)
 	defer cancel()
 	assert.False(t, WaitForReady(ctx))
+}
+
+func TestSetLogOutput(t *testing.T) {
+	oldLevel := GetLogLevel()
+	_ = SetLogLevel("DEBUG")
+	defer SetLogLevel(oldLevel)
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer func() {
+		log.SetOutput(os.Stderr)
+	}()
+
+	log.Info("hello world")
+	assert.True(t, strings.Contains(buf.String(), "hello world"))
 }

--- a/v1/ao/internal/config/config_test.go
+++ b/v1/ao/internal/config/config_test.go
@@ -6,13 +6,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	aolog "github.com/appoptics/appoptics-apm-go/v1/ao/internal/log"
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/log"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/utils"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
@@ -463,8 +462,8 @@ func TestConfigDefaultValues(t *testing.T) {
 	c := newConfig().reset()
 
 	// check default log level
-	level, ok := aolog.ToLogLevel(c.DebugLevel)
-	assert.Equal(t, level, aolog.DefaultLevel)
+	level, ok := log.ToLogLevel(c.DebugLevel)
+	assert.Equal(t, level, log.DefaultLevel)
 	assert.True(t, ok)
 
 	// check default ssl collector url

--- a/v1/ao/internal/host/host_test.go
+++ b/v1/ao/internal/host/host_test.go
@@ -4,7 +4,6 @@ package host
 
 import (
 	"io"
-	"log"
 	"net"
 	"os"
 	"runtime"
@@ -12,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/config"
-	aolog "github.com/appoptics/appoptics-apm-go/v1/ao/internal/log"
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/log"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -24,10 +23,10 @@ func init() {
 func TestFilteredIfaces(t *testing.T) {
 	ifaces, err := FilteredIfaces()
 	if err != nil {
-		log.Printf("Got err from FilteredIfaces: %s\n", err)
+		t.Logf("Got err from FilteredIfaces: %s\n", err)
 	}
 	if len(ifaces) == 0 {
-		log.Println("Got none interfaces.")
+		t.Log("Got none interfaces.")
 	}
 	for _, iface := range ifaces {
 		assert.Equal(t, net.Flags(0), iface.Flags&net.FlagLoopback)
@@ -105,14 +104,14 @@ func TestStopHostIDObserver(t *testing.T) {
 		log.SetOutput(os.Stderr)
 	}()
 
-	aolog.SetLevel(aolog.INFO)
+	log.SetLevel(log.INFO)
 	Stop()
 	assert.True(t, strings.Contains(buf.String(),
 		stopHostIdObserverByUser), buf.String())
 	buf.Reset()
 	Stop()
 	assert.Equal(t, "", buf.String())
-	aolog.SetLevel(aolog.WARNING)
+	log.SetLevel(log.WARNING)
 }
 
 func TestCurrentID(t *testing.T) {

--- a/v1/ao/internal/host/observer_test.go
+++ b/v1/ao/internal/host/observer_test.go
@@ -5,7 +5,6 @@ package host
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -14,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	ao "github.com/appoptics/appoptics-apm-go/v1/ao/internal/log"
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/log"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/utils"
 
 	"github.com/stretchr/testify/assert"
@@ -121,7 +120,7 @@ func TestUpdateHostId(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	ao.SetLevel(ao.DEBUG)
+	log.SetLevel(log.DEBUG)
 	var buf bytes.Buffer
 	log.SetOutput(&buf)
 	defer func() {

--- a/v1/ao/internal/log/logging.go
+++ b/v1/ao/internal/log/logging.go
@@ -53,6 +53,7 @@ const DefaultLevel = WARNING
 // The global log level.
 var (
 	globalLevel = &logLevel{LogLevel: DefaultLevel}
+	logger      = log.New(os.Stderr, "", log.LstdFlags|log.Lmicroseconds)
 )
 
 func init() {
@@ -182,7 +183,7 @@ func logIt(level LogLevel, msg string, args []interface{}) {
 	}
 	buffer.WriteString(s)
 
-	log.Print(buffer.String())
+	logger.Print(buffer.String())
 }
 
 // Logf formats the log message with specified args

--- a/v1/ao/internal/log/logging.go
+++ b/v1/ao/internal/log/logging.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -58,6 +59,11 @@ var (
 
 func init() {
 	SetLevelFromStr(os.Getenv(envAppOpticsLogLevel))
+}
+
+// SetOutput sets the output destination for the internal logger.
+func SetOutput(w io.Writer) {
+	logger.SetOutput(w)
 }
 
 // SetLevelFromStr parses the input string to a LogLevel and change the level of

--- a/v1/ao/internal/log/logging_test.go
+++ b/v1/ao/internal/log/logging_test.go
@@ -5,7 +5,6 @@ package log
 import (
 	"bytes"
 	"io"
-	"log"
 	"math/rand"
 	"os"
 	"strings"
@@ -52,7 +51,7 @@ func TestDebugLevel(t *testing.T) {
 
 func TestLog(t *testing.T) {
 	var buffer bytes.Buffer
-	log.SetOutput(&buffer)
+	SetOutput(&buffer)
 
 	os.Setenv("APPOPTICS_DEBUG_LEVEL", "debug")
 	SetLevelFromStr(os.Getenv(envAppOpticsLogLevel))
@@ -97,7 +96,7 @@ func TestLog(t *testing.T) {
 	Infof("show me the %v", "code")
 	assert.True(t, strings.HasSuffix(buffer.String(), "show me the code\n"))
 
-	log.SetOutput(os.Stderr)
+	SetOutput(os.Stderr)
 	os.Unsetenv("APPOPTICS_DEBUG_LEVEL")
 
 }
@@ -139,10 +138,10 @@ func TestSetLevel(t *testing.T) {
 	writers = append(writers, &buf)
 	writers = append(writers, os.Stderr)
 
-	log.SetOutput(io.MultiWriter(writers...))
+	SetOutput(io.MultiWriter(writers...))
 
 	defer func() {
-		log.SetOutput(os.Stderr)
+		SetOutput(os.Stderr)
 	}()
 
 	SetLevel(INFO)

--- a/v1/ao/internal/metrics/metrics_test.go
+++ b/v1/ao/internal/metrics/metrics_test.go
@@ -4,7 +4,6 @@ package metrics
 
 import (
 	"bytes"
-	"log"
 	"math"
 	"net"
 	"os"
@@ -16,6 +15,7 @@ import (
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/bson"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/hdrhist"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/host"
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/log"
 	"github.com/stretchr/testify/assert"
 	mbson "gopkg.in/mgo.v2/bson"
 )

--- a/v1/ao/internal/reporter/reporter_test.go
+++ b/v1/ao/internal/reporter/reporter_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"os"
 	"reflect"
@@ -18,7 +17,7 @@ import (
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/config"
 	g "github.com/appoptics/appoptics-apm-go/v1/ao/internal/graphtest"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/host"
-	aolog "github.com/appoptics/appoptics-apm-go/v1/ao/internal/log"
+	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/log"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/metrics"
 	pb "github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter/collector"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter/mocks"
@@ -154,7 +153,7 @@ func startTestUDPListener(t *testing.T, bufs *[][]byte, numbufs int) chan struct
 			n, _, err := conn.ReadFromUDP(buf)
 			t.Logf("Got UDP buf len %v err %v", n, err)
 			if err != nil {
-				log.Printf("UDP listener got err, quitting %v", err)
+				t.Logf("UDP listener got err, quitting %v", err)
 				break
 			}
 			*bufs = append(*bufs, buf[0:n])
@@ -363,7 +362,7 @@ func TestInvalidKey(t *testing.T) {
 	config.Load()
 	oldReporter := globalReporter
 
-	aolog.SetLevel(aolog.INFO)
+	log.SetLevel(log.INFO)
 	setGlobalReporter("ssl")
 	require.IsType(t, &grpcReporter{}, globalReporter)
 
@@ -396,9 +395,9 @@ func TestInvalidKey(t *testing.T) {
 		"eventBatchSender goroutine exiting",
 	}
 	for _, ptn := range patterns {
-		assert.True(t, strings.Contains(buf.String(), ptn))
+		assert.True(t, strings.Contains(buf.String(), ptn), buf.String()+"^^^^^^"+ptn)
 	}
-	aolog.SetLevel(aolog.WARNING)
+	log.SetLevel(log.WARNING)
 }
 
 func TestDefaultBackoff(t *testing.T) {


### PR DESCRIPTION
The changes:
- Use microsecond precision for logging timestamp
- Use a standalone logger, rather than the global one, to avoid interfering with other modules

See https://swicloud.atlassian.net/browse/AO-14101