### PR TITLE
AO-9089: Add missing KVs to the __Init message

### DIFF
--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -152,6 +152,9 @@ func sendInitMessage() {
 		_ = e.AddKV("__Init", 1)
 		_ = e.AddKV("Go.Version", utils.GoVersion())
 		_ = e.AddKV("Go.AppOptics.Version", utils.Version())
+		_ = e.AddKV("Go.InstallDirectory", utils.InstallDir())
+		_ = e.AddKV("Go.InstallTimestamp", utils.InstallTsInSec())
+		_ = e.AddKV("Go.LastRestart", utils.LastRestartInUSec())
 
 		_ = e.ReportStatus(c)
 	}

--- a/v1/ao/internal/utils/status.go
+++ b/v1/ao/internal/utils/status.go
@@ -32,14 +32,16 @@ func initInstallDir() string {
 		return "unknown"
 	}
 
-	for path != "/" {
+	prevPath := string(os.PathSeparator)
+	for path != prevPath {
 		base := filepath.Base(path)
 		if base == "ao" {
 			return path
 		}
+		prevPath = path
 		path = filepath.Dir(path)
 	}
-	return path
+	return "unknown"
 }
 
 func initInstallTsInSec() int64 {

--- a/v1/ao/internal/utils/status.go
+++ b/v1/ao/internal/utils/status.go
@@ -1,0 +1,71 @@
+// Copyright (C) 2017 Librato, Inc. All rights reserved.
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+var (
+	installDir        string
+	installTsInSec    int64
+	lastRestartInUSec int64
+)
+
+func init() {
+	installDir = initInstallDir()
+	installTsInSec = initInstallTsInSec()
+	lastRestartInUSec = initLastRestartInUSec()
+}
+
+func initInstallDir() string {
+	_, path, _, ok := runtime.Caller(0)
+	if !ok {
+		return "unknown"
+	}
+
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return "unknown"
+	}
+
+	for path != "/" {
+		base := filepath.Base(path)
+		if base == "ao" {
+			return path
+		}
+		path = filepath.Dir(path)
+	}
+	return path
+}
+
+func initInstallTsInSec() int64 {
+	_, path, _, ok := runtime.Caller(0)
+	if !ok {
+		return 0
+	}
+	fileStat, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return fileStat.ModTime().Unix()
+}
+
+func initLastRestartInUSec() int64 {
+	return time.Now().UnixNano() / 1e3
+}
+
+func InstallDir() string {
+	return installDir
+}
+
+func InstallTsInSec() int64 {
+	return installTsInSec
+}
+
+func LastRestartInUSec() int64 {
+	return lastRestartInUSec
+}


### PR DESCRIPTION
This PR adds 3 missing KVs to the `__Init` message:
`Go.InstallDirectory`, `Go.InstallTimestamp` and `Go.LastRestart`

See https://swicloud.atlassian.net/browse/AO-9089 for more details.