### PR TITLE
AO-14595: Avoid recording HTTP span when the trace is disabled

### DIFF
--- a/v1/ao/internal/reporter/context.go
+++ b/v1/ao/internal/reporter/context.go
@@ -569,6 +569,8 @@ func NewContext(layer string, reportEntry bool, opts ContextOptions,
 	}
 
 	decision := shouldTraceRequestWithURL(layer, traced, opts.URL, tMode)
+	ctx.SetEnabled(decision.enabled)
+
 	if decision.trace {
 		if reportEntry {
 			var kvs map[string]interface{}
@@ -601,7 +603,6 @@ func NewContext(layer string, reportEntry bool, opts ContextOptions,
 	}
 
 	ctx.SetSampled(false)
-	ctx.SetEnabled(decision.enabled)
 	SetHeaders(decision.xTraceOptsRsp)
 
 	return ctx, true, headers

--- a/v1/ao/internal/reporter/oboe.go
+++ b/v1/ao/internal/reporter/oboe.go
@@ -203,9 +203,11 @@ func (b *tokenBucket) update(now time.Time) {
 }
 
 type SampleDecision struct {
-	trace         bool
-	rate          int
-	source        sampleSource
+	trace  bool
+	rate   int
+	source sampleSource
+	// if the request is disabled from tracing in a per-transaction level or for
+	// the entire service.
 	enabled       bool
 	xTraceOptsRsp string
 }

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -231,7 +231,7 @@ func (t *aoTrace) reportExit() {
 		}
 
 		// if this is an HTTP trace, record a new span
-		if !t.httpSpan.start.IsZero() {
+		if !t.httpSpan.start.IsZero() && t.aoCtx.GetEnabled() {
 			t.httpSpan.span.Duration = time.Now().Sub(t.httpSpan.start)
 			t.recordHTTPSpan()
 		}
@@ -299,9 +299,7 @@ func (t *aoTrace) recordHTTPSpan() {
 		t.httpSpan.span.HasError = true
 	}
 
-	if t.aoCtx.GetEnabled() {
-		_ = reporter.ReportSpan(&t.httpSpan.span)
-	}
+	reporter.ReportSpan(&t.httpSpan.span)
 
 	// This will add the TransactionName KV into the exit event.
 	t.endArgs = append(t.endArgs, keyTransactionName, t.httpSpan.span.Transaction)


### PR DESCRIPTION
This PR improves the HTTP span processing, avoids the recording of the span and populating the transaction name when the request is disabled from tracing.
See https://swicloud.atlassian.net/browse/AO-14595