### PR TITLE
AO-15467: Enable gzip compression for gRPC by default

### DIFF
--- a/v1/ao/internal/reporter/reporter_grpc.go
+++ b/v1/ao/internal/reporter/reporter_grpc.go
@@ -24,6 +24,7 @@ import (
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/utils"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/encoding/gzip"
 
 	"context"
 
@@ -1294,10 +1295,15 @@ func (d *DefaultDialer) Dial(p DialParams) (*grpc.ClientConn, error) {
 	}
 	creds := credentials.NewTLS(tlsConfig)
 
-	opts := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(creds),
+		grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)),
+	}
+
 	if p.Proxy != "" {
 		opts = append(opts, grpc.WithContextDialer(newGRPCProxyDialer(p)))
 	}
+
 	return grpc.Dial(p.Address, opts...)
 }
 


### PR DESCRIPTION
Enable gzip compression for the gRPC connection.

See https://swicloud.atlassian.net/browse/AO-15467