### PR TITLE
AO-15694: Remove skip verify option

### DIFF
--- a/v1/ao/internal/config/config.go
+++ b/v1/ao/internal/config/config.go
@@ -49,7 +49,6 @@ const (
 	envAppOpticsSampleRate          = "APPOPTICS_SAMPLE_RATE"
 	envAppOpticsPrependDomain       = "APPOPTICS_PREPEND_DOMAIN"
 	envAppOpticsHostnameAlias       = "APPOPTICS_HOSTNAME_ALIAS"
-	envAppOpticsInsecureSkipVerify  = "APPOPTICS_INSECURE_SKIP_VERIFY"
 	envAppOpticsHistogramPrecision  = "APPOPTICS_HISTOGRAM_PRECISION"
 	envAppOpticsEventsFlushInterval = "APPOPTICS_EVENTS_FLUSH_INTERVAL"
 	envAppOpticsMaxReqBytes         = "APPOPTICS_MAX_REQUEST_BYTES"
@@ -92,9 +91,6 @@ type Config struct {
 
 	// The alias of the hostname
 	HostAlias string `yaml:"HostAlias,omitempty" env:"APPOPTICS_HOSTNAME_ALIAS"`
-
-	// Whether to skip verification of hostname
-	SkipVerify bool `yaml:"SkipVerify,omitempty" env:"APPOPTICS_INSECURE_SKIP_VERIFY" default:"true"`
 
 	// The precision of the histogram
 	Precision int `yaml:"Precision,omitempty" env:"APPOPTICS_HISTOGRAM_PRECISION" default:"2"`
@@ -776,13 +772,6 @@ func (c *Config) GetHostAlias() string {
 	c.RLock()
 	defer c.RUnlock()
 	return c.HostAlias
-}
-
-// GetSkipVerify returns the config of skipping hostname verification
-func (c *Config) GetSkipVerify() bool {
-	c.RLock()
-	defer c.RUnlock()
-	return c.SkipVerify
 }
 
 // GetPrecision returns the histogram precision

--- a/v1/ao/internal/config/config_test.go
+++ b/v1/ao/internal/config/config_test.go
@@ -57,7 +57,6 @@ func TestLoadConfig(t *testing.T) {
 
 	os.Setenv(envAppOpticsServiceKey, key1)
 	os.Setenv(envAppOpticsHostnameAlias, "test")
-	os.Setenv(envAppOpticsInsecureSkipVerify, "false")
 	os.Setenv(envAppOpticsTrustedPath, "test.crt")
 	os.Setenv(envAppOpticsCollectorUDP, "hello.udp")
 	os.Setenv(envAppOpticsDisabled, "invalidValue")
@@ -65,7 +64,6 @@ func TestLoadConfig(t *testing.T) {
 	c.Load()
 	assert.Equal(t, ToServiceKey(key1), c.GetServiceKey())
 	assert.Equal(t, "test", c.GetHostAlias())
-	assert.Equal(t, false, c.GetSkipVerify())
 	assert.Equal(t, "test.crt", filepath.Base(c.GetTrustedPath()))
 	assert.Equal(t, "hello.udp", c.GetCollectorUDP())
 	assert.Equal(t, false, c.GetDisabled())
@@ -130,7 +128,6 @@ func TestConfigInit(t *testing.T) {
 		},
 		PrependDomain: false,
 		HostAlias:     "",
-		SkipVerify:    true,
 		Precision:     2,
 		ReporterProperties: &ReporterOptions{
 			EventFlushInterval:      2,
@@ -186,7 +183,7 @@ func TestEnvsLoading(t *testing.T) {
 		"APPOPTICS_SAMPLE_RATE=1000",
 		"APPOPTICS_PREPEND_DOMAIN=true",
 		"APPOPTICS_HOSTNAME_ALIAS=alias",
-		"APPOPTICS_INSECURE_SKIP_VERIFY=true",
+
 		"APPOPTICS_HISTOGRAM_PRECISION=4",
 		"APPOPTICS_EVENTS_FLUSH_INTERVAL=4",
 		"APPOPTICS_MAX_REQUEST_BYTES=4096000",
@@ -214,7 +211,6 @@ func TestEnvsLoading(t *testing.T) {
 		},
 		PrependDomain: true,
 		HostAlias:     "alias",
-		SkipVerify:    true,
 		Precision:     2 * 2,
 		ReporterProperties: &ReporterOptions{
 			EventFlushInterval:      2 * 2,
@@ -259,7 +255,6 @@ func TestYamlConfig(t *testing.T) {
 		},
 		PrependDomain: true,
 		HostAlias:     "yaml-alias",
-		SkipVerify:    true,
 		Precision:     2 * 3,
 		ReporterProperties: &ReporterOptions{
 			EventFlushInterval:      2 * 3,
@@ -312,7 +307,6 @@ func TestYamlConfig(t *testing.T) {
 		"APPOPTICS_SAMPLE_RATE=1000",
 		"APPOPTICS_PREPEND_DOMAIN=true",
 		"APPOPTICS_HOSTNAME_ALIAS=alias",
-		"APPOPTICS_INSECURE_SKIP_VERIFY=true",
 		"APPOPTICS_HISTOGRAM_PRECISION=4",
 		"APPOPTICS_EVENTS_FLUSH_INTERVAL=4",
 		"APPOPTICS_MAX_REQUEST_BYTES=4096000",
@@ -337,7 +331,6 @@ func TestYamlConfig(t *testing.T) {
 		},
 		PrependDomain: true,
 		HostAlias:     "alias",
-		SkipVerify:    true,
 		Precision:     2 * 2,
 		ReporterProperties: &ReporterOptions{
 			EventFlushInterval:      2 * 2,
@@ -444,7 +437,6 @@ func TestInvalidConfig(t *testing.T) {
 		},
 		PrependDomain: true,
 		HostAlias:     "alias",
-		SkipVerify:    true,
 		Precision:     2 * 2,
 		ReporterProperties: &ReporterOptions{
 			EventFlushInterval:      2 * 2,

--- a/v1/ao/internal/config/wrappers.go
+++ b/v1/ao/internal/config/wrappers.go
@@ -36,9 +36,6 @@ var GetPrependDomain = conf.GetPrependDomain
 // GetHostAlias is a wrapper to the method of the global config
 var GetHostAlias = conf.GetHostAlias
 
-// GetSkipVerify is a wrapper to the method of the global config
-var GetSkipVerify = conf.GetSkipVerify
-
 // GetPrecision is a wrapper to the method of the global config
 var GetPrecision = conf.GetPrecision
 

--- a/v1/ao/internal/reporter/reporter_test.go
+++ b/v1/ao/internal/reporter/reporter_test.go
@@ -429,13 +429,12 @@ func TestInvokeRPC(t *testing.T) {
 	}()
 
 	c := &grpcConnection{
-		name:               "events channel",
-		client:             nil,
-		connection:         nil,
-		address:            "test-addr",
-		certificate:        []byte(grpcCertDefault),
-		queueStats:         &metrics.EventQueueStats{},
-		insecureSkipVerify: true,
+		name:        "events channel",
+		client:      nil,
+		connection:  nil,
+		address:     "test-addr",
+		certificate: []byte(grpcCertDefault),
+		queueStats:  &metrics.EventQueueStats{},
 		backoff: func(retries int, wait func(d time.Duration)) error {
 			if retries > grpcMaxRetries {
 				return errGiveUpAfterRetries


### PR DESCRIPTION
Remove the insecureSkipVerify option from the agent as it's no longer needed.

See https://swicloud.atlassian.net/browse/AO-15694