### PR TITLE
AO-16200: Metrics count should be positive

### DIFF
--- a/v1/ao/internal/reporter/reporter_test.go
+++ b/v1/ao/internal/reporter/reporter_test.go
@@ -595,6 +595,18 @@ func TestCustomMetrics(t *testing.T) {
 		customMetrics: metrics.NewMeasurements(true, grpcMetricIntervalDefault, 500),
 	}
 
+	// Test non-positive count
+	assert.NotNil(t, r.CustomSummaryMetric("Summary", 1.1, metrics.MetricOptions{
+		Count:   0,
+		HostTag: true,
+		Tags:    map[string]string{"hello": "world"},
+	}))
+	assert.NotNil(t, r.CustomIncrementMetric("Incremental", metrics.MetricOptions{
+		Count:   -1,
+		HostTag: true,
+		Tags:    map[string]string{"hi": "globe"},
+	}))
+
 	r.CustomSummaryMetric("Summary", 1.1, metrics.MetricOptions{
 		Count:   1,
 		HostTag: true,

--- a/v1/ao/metrics.go
+++ b/v1/ao/metrics.go
@@ -3,8 +3,6 @@
 package ao
 
 import (
-	"errors"
-
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/metrics"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
 )
@@ -14,31 +12,27 @@ type MetricOptions = metrics.MetricOptions
 
 const (
 	// MaxTagsCount is the maximum number of tags allowed.
-	MaxTagsCount = 50
+	MaxTagsCount = metrics.MaxTagsCount
 )
 
 // The measurements submission errors
 var (
 	// ErrExceedsTagsCountLimit indicates the count of tags exceeds the limit
-	ErrExceedsTagsCountLimit = errors.New("exceeds tags count limit")
+	ErrExceedsTagsCountLimit = metrics.ErrExceedsTagsCountLimit
 	// ErrExceedsMetricsCountLimit indicates there are too many distinct measurements in a flush cycle.
 	ErrExceedsMetricsCountLimit = metrics.ErrExceedsMetricsCountLimit
+	// ErrMetricsWithNonPositiveCount indicates the count is negative or zero
+	ErrMetricsWithNonPositiveCount = metrics.ErrMetricsWithNonPositiveCount
 )
 
 // SummaryMetric submits a summary type measurement to the reporter. The measurements
 // will be collected in the background and reported periodically.
 func SummaryMetric(name string, value float64, opts MetricOptions) error {
-	if len(opts.Tags) > MaxTagsCount {
-		return ErrExceedsTagsCountLimit
-	}
 	return reporter.SummaryMetric(name, value, opts)
 }
 
 // IncrementMetric submits a incremental measurement to the reporter. The measurements
 // will be collected in the background and reported periodically.
 func IncrementMetric(name string, opts MetricOptions) error {
-	if len(opts.Tags) > MaxTagsCount {
-		return ErrExceedsTagsCountLimit
-	}
 	return reporter.IncrementMetric(name, opts)
 }


### PR DESCRIPTION
The `count` in the reported metrics should always be positive.

See https://swicloud.atlassian.net/browse/AO-16200