### PR TITLE
AO-16200: Release v1.13.1

### DIFF
--- a/v1/ao/internal/utils/version.go
+++ b/v1/ao/internal/utils/version.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	// The AppOptics Go agent version
-	version = "1.13.0"
+	version = "1.13.1"
 
 	// The Go version
 	goVersion = strings.TrimPrefix(runtime.Version(), "go")


### PR DESCRIPTION
With the following PRs:
- Enable gRPC compression by default: https://github.com/appoptics/appoptics-apm-go/pull/140
- Remove skip verify option: https://github.com/appoptics/appoptics-apm-go/pull/141
- Go versions support: Add Go 1.14, remove 1.12: https://github.com/appoptics/appoptics-apm-go/pull/142
- Metrics count should be positive only: https://github.com/appoptics/appoptics-apm-go/pull/143