### PR TITLE
AO-17468: Transaction name improvements

### DIFF
--- a/v1/ao/http_instrumentation.go
+++ b/v1/ao/http_instrumentation.go
@@ -158,8 +158,8 @@ func traceFromHTTPRequest(spanName string, r *http.Request, isNewContext bool, o
 
 	// start trace, passing in metadata header
 	t := NewTraceWithOptions(spanName, SpanOptions{
-		false,
-		reporter.ContextOptions{
+		WithBackTrace: false,
+		ContextOptions: reporter.ContextOptions{
 			MdStr:                  r.Header.Get(HTTPHeaderName),
 			URL:                    r.URL.EscapedPath(),
 			XTraceOptions:          r.Header.Get(HTTPHeaderXTraceOptions),

--- a/v1/ao/internal/metrics/metrics.go
+++ b/v1/ao/internal/metrics/metrics.go
@@ -33,7 +33,7 @@ const (
 
 // Special transaction names
 const (
-	UnknownTransactionName       = "unknown"
+	CustomTransactionNamePrefix  = "custom"
 	OtherTransactionName         = "other"
 	MetricIDSeparator            = "&"
 	TagsKVSeparator              = ":"
@@ -642,11 +642,6 @@ func GetTransactionFromPath(path string) string {
 func (s *HTTPSpanMessage) Process(m *Measurements) {
 	// always add to overall histogram
 	recordHistogram(metricsHTTPHistograms, "", s.Duration)
-
-	if s.Transaction == UnknownTransactionName {
-		s.processMeasurements(nil, m)
-		return
-	}
 
 	// only record the transaction-specific histogram and measurements if we are still within the limit
 	// otherwise report it as an 'other' measurement

--- a/v1/ao/layer.go
+++ b/v1/ao/layer.go
@@ -131,6 +131,7 @@ type SpanOptions struct {
 	WithBackTrace bool
 
 	ContextOptions
+	TransactionName string
 }
 
 // SpanOpt defines the function type that changes the SpanOptions

--- a/v1/ao/layer.go
+++ b/v1/ao/layer.go
@@ -433,6 +433,10 @@ func (l spanLabeler) layerName() string          { return l.name }
 func (l spanLabeler) setName(name string)        { l.name = name }
 
 func newSpan(aoCtx reporter.Context, spanName string, parent Span, args ...interface{}) Span {
+	if spanName == "" {
+		return nullSpan{}
+	}
+
 	ll := spanLabeler{spanName}
 	if err := aoCtx.ReportEvent(ll.entryLabel(), ll.layerName(), args...); err != nil {
 		return nullSpan{}

--- a/v1/ao/layer_test.go
+++ b/v1/ao/layer_test.go
@@ -203,7 +203,7 @@ func TestWithTransactionFiltering(t *testing.T) {
 
 	// 2. “disabled” transaction settings not matched
 	r = reporter.SetTestReporter()
-	tr = NewTraceWithOptions(layerName, SpanOptions{false, ContextOptions{URL: "/eric"}})
+	tr = NewTraceWithOptions(layerName, SpanOptions{WithBackTrace: false, ContextOptions: ContextOptions{URL: "/eric"}})
 	tr.End()
 	r.Close(2)
 	assert.Equal(t, 2, len(r.EventBufs))
@@ -211,7 +211,7 @@ func TestWithTransactionFiltering(t *testing.T) {
 
 	// 3.1 “disabled” transaction settings matched
 	r = reporter.SetTestReporter()
-	tr = NewTraceWithOptions(layerName, SpanOptions{false, ContextOptions{URL: "/test1"}})
+	tr = NewTraceWithOptions(layerName, SpanOptions{WithBackTrace: false, ContextOptions: ContextOptions{URL: "/test1"}})
 	tr.End()
 	r.Close(0)
 	assert.Equal(t, 0, len(r.EventBufs))
@@ -219,7 +219,7 @@ func TestWithTransactionFiltering(t *testing.T) {
 
 	// 3.2 “disabled” transaction settings matched
 	r = reporter.SetTestReporter()
-	tr = NewTraceWithOptions(layerName, SpanOptions{false, ContextOptions{URL: "/eric.jpg"}})
+	tr = NewTraceWithOptions(layerName, SpanOptions{WithBackTrace: false, ContextOptions: ContextOptions{URL: "/eric.jpg"}})
 	tr.End()
 	r.Close(0)
 	assert.Equal(t, 0, len(r.EventBufs))
@@ -278,7 +278,7 @@ func TestWithTransactionFiltering(t *testing.T) {
 
 	// 9.“enabled” transaction settings not matched
 	r = reporter.SetTestReporter()
-	tr = NewTraceWithOptions(layerName, SpanOptions{false, ContextOptions{URL: "/eric"}})
+	tr = NewTraceWithOptions(layerName, SpanOptions{WithBackTrace: false, ContextOptions: ContextOptions{URL: "/eric"}})
 	tr.End()
 	r.Close(0)
 	assert.Equal(t, 0, len(r.EventBufs))
@@ -286,7 +286,7 @@ func TestWithTransactionFiltering(t *testing.T) {
 
 	// 10.“enabled” transaction settings matching
 	r = reporter.SetTestReporter()
-	tr = NewTraceWithOptions(layerName, SpanOptions{false, ContextOptions{URL: "/test1"}})
+	tr = NewTraceWithOptions(layerName, SpanOptions{WithBackTrace: false, ContextOptions: ContextOptions{URL: "/test1"}})
 	tr.End()
 	r.Close(2)
 	assert.Equal(t, 2, len(r.EventBufs))

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -133,6 +133,10 @@ func NewTraceWithOptions(spanName string, opts SpanOptions) Trace {
 		layerSpan:      layerSpan{span: span{aoCtx: ctx, labeler: spanLabeler{spanName}}},
 		httpRspHeaders: make(map[string]string),
 	}
+
+	if opts.TransactionName != "" {
+		t.SetTransactionName(opts.TransactionName)
+	}
 	t.SetStartTime(time.Now())
 	t.SetHTTPRspHeaders(headers)
 	return t
@@ -150,8 +154,8 @@ func NewTraceFromID(spanName, mdStr string, cb func() KVMap) Trace {
 // If callback is provided & trace is sampled, cb will be called for entry event KVs
 func NewTraceFromIDForURL(spanName, mdStr string, url string, cb func() KVMap) Trace {
 	return NewTraceWithOptions(spanName, SpanOptions{
-		false,
-		ContextOptions{
+		WithBackTrace: false,
+		ContextOptions: ContextOptions{
 			MdStr: mdStr,
 			URL:   url,
 			CB:    cb,

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -3,6 +3,7 @@
 package ao
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -326,16 +327,14 @@ func (t *aoTrace) finalizeTxnName(controller string, action string) {
 	}
 
 	if t.httpSpan.span.Transaction == "" {
-		t.httpSpan.span.Transaction = metrics.UnknownTransactionName
+		t.httpSpan.span.Transaction = fmt.Sprintf("%s-%s", metrics.CustomTransactionNamePrefix, t.layerName())
 	}
 	t.prependDomainToTxnName()
 }
 
 // prependDomainToTxnName prepends the domain to the transaction name if APPOPTICS_PREPEND_DOMAIN = true
 func (t *aoTrace) prependDomainToTxnName() {
-	if !config.GetPrependDomain() ||
-		t.httpSpan.span.Transaction == metrics.UnknownTransactionName ||
-		t.httpSpan.span.Host == "" {
+	if !config.GetPrependDomain() || t.httpSpan.span.Host == "" {
 		return
 	}
 	if strings.HasSuffix(t.httpSpan.span.Host, "/") ||

--- a/v1/ao/trace.go
+++ b/v1/ao/trace.go
@@ -109,7 +109,7 @@ func NewTrace(spanName string) Trace {
 
 // NewTraceWithOptions creates a new trace with the provided options
 func NewTraceWithOptions(spanName string, opts SpanOptions) Trace {
-	if Closed() {
+	if Closed() || spanName == "" {
 		return NewNullTrace()
 	}
 


### PR DESCRIPTION
Two changes:
1. Set the transaction name when creating a new trace
2. Use a default transaction name ("custom-<top span name>") if it's not set.

See also: https://swicloud.atlassian.net/browse/AO-17468