### PR TITLE
AO-16881: service name might be absent

### DIFF
--- a/v1/ao/internal/config/validators.go
+++ b/v1/ao/internal/config/validators.go
@@ -88,7 +88,7 @@ func IsValidFile(file string) bool {
 // IsValidReporterType checks if the reporter type is valid.
 func IsValidReporterType(t string) bool {
 	t = strings.ToLower(strings.TrimSpace(t))
-	return t == "ssl" || t == "udp"
+	return t == "ssl" || t == "udp" || t == "serverless"
 }
 
 // IsValidEc2MetadataTimeout checks if the timeout is within the designated range

--- a/v1/ao/internal/config/validators.go
+++ b/v1/ao/internal/config/validators.go
@@ -159,5 +159,9 @@ func MaskServiceKey(validKey string) string {
 	tk = tk[0:4] + strings.Repeat(mask,
 		utf8.RuneCountInString(tk)-hLen-tLen) + tk[len(tk)-4:]
 
-	return tk + sep + s[1]
+	masked := tk + sep
+	if len(s) >= 2 {
+		masked += s[1]
+	}
+	return masked
 }

--- a/v1/ao/internal/config/validators_test.go
+++ b/v1/ao/internal/config/validators_test.go
@@ -73,6 +73,7 @@ func TestIsValidReporterType(t *testing.T) {
 	assert.Equal(t, false, IsValidReporterType("xxx"))
 	assert.Equal(t, false, IsValidReporterType(""))
 	assert.Equal(t, false, IsValidReporterType("udpabc"))
+	assert.Equal(t, true, IsValidReporterType("serverless"))
 }
 
 func TestConverters(t *testing.T) {


### PR DESCRIPTION
An issue is found during the tests that after the service key check is lifted for lambda, the service key masking may panic due to invalid array index access.