### PR TITLE
AO-16881: Process invalid bucket config

### DIFF
--- a/v1/ao/internal/config/config.go
+++ b/v1/ao/internal/config/config.go
@@ -36,6 +36,8 @@ const (
 	maxConfigFileSize = 1024 * 1024
 	// the default collector url
 	defaultSSLCollector = "collector.appoptics.com:443"
+	maxTokenBucketCapacity = 8
+	maxTokenBucketRate =4
 )
 
 // The environment variables
@@ -383,14 +385,12 @@ func (c *Config) validate() error {
 
 	if valid := IsValidTokenBucketCap(c.TokenBucketCap); !valid {
 		log.Warning(InvalidEnv("TokenBucketCap", fmt.Sprintf("%f", c.TokenBucketCap)))
-		cp, _ := strconv.ParseFloat(getFieldDefaultValue(c, "TokenBucketCap"), 64)
-		c.TokenBucketCap = cp
+		c.TokenBucketCap = maxTokenBucketCapacity
 	}
 
 	if valid := IsValidTokenBucketRate(c.TokenBucketRate); !valid {
 		log.Warning(InvalidEnv("TokenBucketRate", fmt.Sprintf("%f", c.TokenBucketRate)))
-		rate, _ := strconv.ParseFloat(getFieldDefaultValue(c, "TokenBucketRate"), 64)
-		c.TokenBucketRate = rate
+		c.TokenBucketRate = maxTokenBucketRate
 	}
 
 	return c.ReporterProperties.validate()
@@ -562,7 +562,7 @@ func initStruct(c interface{}) interface{} {
 			initStruct(getValPtr(cVal.Field(i)).Interface())
 		} else {
 			tagVal := getFieldDefaultValue(c, field.Name)
-			defaultVal := stringToValue(tagVal, field.Type)
+			defaultVal, _ := stringToValue(tagVal, field.Type)
 
 			resetMethod := fmt.Sprintf("%s%s", "Reset", field.Name)
 			var prefix string

--- a/v1/ao/internal/config/config.go
+++ b/v1/ao/internal/config/config.go
@@ -385,12 +385,20 @@ func (c *Config) validate() error {
 
 	if valid := IsValidTokenBucketCap(c.TokenBucketCap); !valid {
 		log.Warning(InvalidEnv("TokenBucketCap", fmt.Sprintf("%f", c.TokenBucketCap)))
-		c.TokenBucketCap = maxTokenBucketCapacity
+		if c.TokenBucketCap < 0 {
+			c.TokenBucketCap = 0;
+		} else {
+			c.TokenBucketCap = maxTokenBucketCapacity
+		}
 	}
 
 	if valid := IsValidTokenBucketRate(c.TokenBucketRate); !valid {
 		log.Warning(InvalidEnv("TokenBucketRate", fmt.Sprintf("%f", c.TokenBucketRate)))
-		c.TokenBucketRate = maxTokenBucketRate
+		if c.TokenBucketRate < 0 {
+			c.TokenBucketRate = 0
+		} else {
+			c.TokenBucketRate = maxTokenBucketRate
+		}
 	}
 
 	return c.ReporterProperties.validate()

--- a/v1/ao/internal/config/config_test.go
+++ b/v1/ao/internal/config/config_test.go
@@ -180,6 +180,38 @@ func SetEnvs(kvs []string) {
 	}
 }
 
+func TestTokenBucketConfigOverRange(t *testing.T) {
+	ClearEnvs()
+
+	envs := []string{
+		"APPOPTICS_SERVICE_KEY=ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189217:go",
+		"APPOPTICS_TOKEN_BUCKET_CAPACITY=10",
+		"APPOPTICS_TOKEN_BUCKET_RATE=10",
+	}
+	SetEnvs(envs)
+
+	c := NewConfig()
+
+	assert.Equal(t, c.TokenBucketCap, 8.0)
+	assert.Equal(t, c.TokenBucketRate, 4.0)
+}
+
+func TestTokenBucketConfigInvalidValue(t *testing.T) {
+	ClearEnvs()
+
+	envs := []string{
+		"APPOPTICS_SERVICE_KEY=ae38315f6116585d64d82ec2455aa3ec61e02fee25d286f74ace9e4fea189217:go",
+		"APPOPTICS_TOKEN_BUCKET_CAPACITY=hello",
+		"APPOPTICS_TOKEN_BUCKET_RATE=hi",
+	}
+	SetEnvs(envs)
+
+	c := NewConfig()
+
+	assert.Equal(t, c.TokenBucketCap, 8.0)
+	assert.Equal(t, c.TokenBucketRate, 0.17)
+}
+
 func TestEnvsLoading(t *testing.T) {
 	ClearEnvs()
 

--- a/v1/ao/internal/config/env.go
+++ b/v1/ao/internal/config/env.go
@@ -55,13 +55,16 @@ func loadEnvsInternal(c interface{}) {
 				continue
 			}
 
-			setField(c, "Set", field, stringToValue(envVal, fieldV.Type()))
+			val, err := stringToValue(envVal, fieldV.Type())
+			if err == nil {
+				setField(c, "Set", field, val)
+			}
 		}
 	}
 }
 
 // stringToValue converts a string to a value of the type specified by typ.
-func stringToValue(s string, typ reflect.Type) reflect.Value {
+func stringToValue(s string, typ reflect.Type) (reflect.Value, error) {
 	s = strings.TrimSpace(s)
 
 	var val interface{}
@@ -105,7 +108,7 @@ func stringToValue(s string, typ reflect.Type) reflect.Value {
 		}
 	case reflect.Slice:
 		if s == "" {
-			return reflect.Zero(typ)
+			return reflect.Zero(typ), nil
 		} else {
 			panic(fmt.Sprintf("Slice with non-empty value is not supported"))
 		}
@@ -114,5 +117,5 @@ func stringToValue(s string, typ reflect.Type) reflect.Value {
 		panic(fmt.Sprintf("Unsupported kind: %v, val: %s", kind, s))
 	}
 	// convert to the target type as `typ` may be a user defined type
-	return reflect.ValueOf(val).Convert(typ)
+	return reflect.ValueOf(val).Convert(typ), err
 }

--- a/v1/ao/internal/config/env_test.go
+++ b/v1/ao/internal/config/env_test.go
@@ -56,26 +56,34 @@ func TestStringToValue(t *testing.T) {
 	type NewStr string
 	typNewStr := reflect.TypeOf(NewStr("newStr"))
 
-	assert.Equal(t, stringToValue("1", typInt).Interface(), 1)
-	assert.Equal(t, stringToValue("1", typInt).Kind(), reflect.Int)
+	stringToValueWrapper := func (s string, typ reflect.Type) reflect.Value {
+		val, _ := stringToValue(s, typ)
+		return val
+	}
 
-	assert.Equal(t, stringToValue("", typInt).Interface(), 0)
-	assert.Equal(t, stringToValue("a", typInt).Interface(), 0)
+	_, err := stringToValue("hi", typInt)
+	assert.NotNil(t, err)
 
-	assert.Equal(t, stringToValue("1", typInt64).Interface(), int64(1))
-	assert.Equal(t, stringToValue("1", typInt64).Kind(), reflect.Int64)
-	assert.Equal(t, stringToValue("", typInt64).Interface(), int64(0))
-	assert.Equal(t, stringToValue("a", typInt64).Interface(), int64(0))
+	assert.Equal(t, stringToValueWrapper("1", typInt).Interface(), 1)
+	assert.Equal(t, stringToValueWrapper("1", typInt).Kind(), reflect.Int)
 
-	assert.Equal(t, stringToValue("a", typString).Interface(), "a")
-	assert.Equal(t, stringToValue("a", typString).Kind(), reflect.String)
-	assert.Equal(t, stringToValue("1", typString).Interface(), "1")
-	assert.Equal(t, stringToValue("A", typString).Interface(), "A")
+	assert.Equal(t, stringToValueWrapper("", typInt).Interface(), 0)
+	assert.Equal(t, stringToValueWrapper("a", typInt).Interface(), 0)
 
-	assert.Equal(t, stringToValue("yes", typBool).Interface(), true)
-	assert.Equal(t, stringToValue("yes", typBool).Kind(), reflect.Bool)
-	assert.Equal(t, stringToValue("false", typBool).Interface(), false)
+	assert.Equal(t, stringToValueWrapper("1", typInt64).Interface(), int64(1))
+	assert.Equal(t, stringToValueWrapper("1", typInt64).Kind(), reflect.Int64)
+	assert.Equal(t, stringToValueWrapper("", typInt64).Interface(), int64(0))
+	assert.Equal(t, stringToValueWrapper("a", typInt64).Interface(), int64(0))
 
-	assert.Equal(t, stringToValue("hello", typNewStr).Interface(), NewStr("hello"))
-	assert.Equal(t, stringToValue("hello", typNewStr).Type(), reflect.TypeOf(NewStr("hello")))
+	assert.Equal(t, stringToValueWrapper("a", typString).Interface(), "a")
+	assert.Equal(t, stringToValueWrapper("a", typString).Kind(), reflect.String)
+	assert.Equal(t, stringToValueWrapper("1", typString).Interface(), "1")
+	assert.Equal(t, stringToValueWrapper("A", typString).Interface(), "A")
+
+	assert.Equal(t, stringToValueWrapper("yes", typBool).Interface(), true)
+	assert.Equal(t, stringToValueWrapper("yes", typBool).Kind(), reflect.Bool)
+	assert.Equal(t, stringToValueWrapper("false", typBool).Interface(), false)
+
+	assert.Equal(t, stringToValueWrapper("hello", typNewStr).Interface(), NewStr("hello"))
+	assert.Equal(t, stringToValueWrapper("hello", typNewStr).Type(), reflect.TypeOf(NewStr("hello")))
 }

--- a/v1/ao/internal/config/validators.go
+++ b/v1/ao/internal/config/validators.go
@@ -107,11 +107,11 @@ func IsValidSampleRate(rate int) bool {
 }
 
 func IsValidTokenBucketRate(rate float64) bool {
-	return rate >= 0 && rate <= 4
+	return rate >= 0 && rate <= maxTokenBucketRate
 }
 
 func IsValidTokenBucketCap(cap float64) bool {
-	return cap >= 0 && cap <= 8
+	return cap >= 0 && cap <= maxTokenBucketCapacity
 }
 
 // NormalizeTracingMode converts an old-style tracing mode (always/never) to a


### PR DESCRIPTION
Process invalid token bucket configurations as per the spec.
- use the default value when the config is of an invalid type (e.g., string)
- set it to the upper limit when the config value is out of range.