### PR TITLE
AO-19983: Add HTTPMethod to the http client span

### DIFF
--- a/v1/ao/http_client_instrumentation.go
+++ b/v1/ao/http_client_instrumentation.go
@@ -25,7 +25,7 @@ type HTTPClientSpan struct{ Span }
 // metadata.
 func BeginHTTPClientSpan(ctx context.Context, req *http.Request) HTTPClientSpan {
 	if req != nil {
-		l := BeginRemoteURLSpan(ctx, "http.Client", req.URL.String())
+		l := BeginRemoteURLSpan(ctx, "http.Client", req.URL.String(), "HTTPMethod", req.Method)
 		req.Header.Set(HTTPHeaderName, l.MetadataString())
 		return HTTPClientSpan{Span: l}
 	}


### PR DESCRIPTION
Add a KV `HTTPMethod` to the http client span to make it show properly on the remote services UI.

See also: https://swicloud.atlassian.net/browse/AO-19983