### PR TITLE
AO-19984: Add go1.16 to the test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goversion: ['1.12', '1.13', '1.14', '1.15']
+        goversion: ['1.12', '1.13', '1.14', '1.15', '1.16']
     name: Go ${{ matrix.goversion }} tests
     env:
       GO15VENDOREXPERIMENT: 1

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/coocood/freecache v1.1.0
 	github.com/golang/protobuf v1.4.2
+	github.com/hashicorp/go-version v1.3.0
 	github.com/opentracing/basictracer-go v1.1.0
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
+github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/opentracing/basictracer-go v1.1.0 h1:Oa1fTSBvAl8pa3U+IJYqrKm0NALwH9OsgwOqDv4xJW0=

--- a/v1/ao/context_test.go
+++ b/v1/ao/context_test.go
@@ -11,6 +11,7 @@ import (
 
 	g "github.com/appoptics/appoptics-apm-go/v1/ao/internal/graphtest"
 	"github.com/appoptics/appoptics-apm-go/v1/ao/internal/reporter"
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -118,7 +119,11 @@ func TestNilContext(t *testing.T) {
 	assert.NotPanics(t, func() { Info(nil, "k", "v") })
 	assert.NotPanics(t, func() { assert.Empty(t, MetadataString(nil)) })
 	assert.NotPanics(t, func() { assert.False(t, IsSampled(nil)) })
-	if strings.HasPrefix(runtime.Version(), "go1.15") {
+
+	baselineV, _ := version.NewSemver("1.15")
+	v, _ := version.NewSemver(strings.TrimLeft(runtime.Version(), "go"))
+
+	if v.GreaterThanOrEqual(baselineV) {
 		// Go 1.15 introduced panic behavior when passing nil contexts around https://golang.org/doc/go1.15#context
 		assert.Panics(t, func() { NewContext(nil, TraceFromContext(nil)) })
 	} else {


### PR DESCRIPTION
Add go1.16 to the test matrix.
See also https://swicloud.atlassian.net/browse/AO-19984